### PR TITLE
uaclient: add helper script for azure cleanup

### DIFF
--- a/ubuntu-advantage-client/azure_cleanup.py
+++ b/ubuntu-advantage-client/azure_cleanup.py
@@ -5,6 +5,7 @@
 # Lucas Moura <lucas.moura@canonical.com>
 import os
 import json
+import sys
 
 from pycloudlib.azure.util import get_client
 from azure.mgmt.resource import ResourceManagementClient
@@ -15,7 +16,7 @@ import argparse
 CI_DEFAULT_TAG = "uaclient"
 
 
-def parse_args():
+def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "-t", "--tag", dest="tag", action="store", default=CI_DEFAULT_TAG,
@@ -50,7 +51,7 @@ def parse_args():
             """
         )
 
-    return parser.parse_args()
+    return parser
 
 
 def clean_azure(tag, client_id, client_secret, tenant_id, subscription_id):
@@ -96,7 +97,19 @@ def load_azure_config(credentials_file):
 
 
 if __name__ == '__main__':
-    args = parse_args()
+    parser = get_parser()
+    args = parser.parse_args()
+    individ_args = all(
+        [
+            args.client_id, args.client_secret,
+            args.tenant_id, args.subscription_id
+        ]
+    )
+    if not any([args.credentials_file, individ_args]):
+        print("Either --credentials-file or tenant and client args required")
+        parser.print_help()
+        sys.exit(1)
+
     if args.credentials_file:
         if not os.path.exists(args.credentials_file):
             raise Exception("File {} could not be found".format(

--- a/ubuntu-advantage-client/azure_cleanup.py
+++ b/ubuntu-advantage-client/azure_cleanup.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Clean up all running Azure resources and resource groups."""
+
+# Copyright 2020 Canonical Ltd.
+# Lucas Moura <lucas.moura@canonical.com>
+
+from pycloudlib.azure.util import get_client
+from azure.mgmt.compute import ComputeManagementClient
+from azure.mgmt.resource import ResourceManagementClient
+
+import argparse
+
+
+CI_DEFAULT_TAG = "uaclient"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-t", "--tag", dest="tag", action="store", default=CI_DEFAULT_TAG,
+        help=("Tag used to filter cloud resources for deletion. "
+              "Default: {}".format(CI_DEFAULT_TAG))
+    )
+    parser.add_argument(
+        "--client-id", dest="client_id", 
+        help="Client id used to access azure api"
+    )
+    parser.add_argument(
+        "--client-secret", dest="client_secret", 
+        help="Client secret used to access azure api"
+    )
+    parser.add_argument(
+        "--tenant-id", dest="tenant_id", 
+        help="Tenant id used to access azure api"
+    )
+    parser.add_argument(
+        "--subscription-id", dest="subscription_id", 
+        help="Subscription id used to access azure api"
+    )
+    return parser.parse_args()
+
+
+def clean_azure(tag, client_id, client_secret, tenant_id, subscription_id):
+    """Clean up all running Azure resources and resource groups"""
+    config_dict = {
+        "clientId": client_id,
+        "clientSecret": client_secret,
+        "tenantId": tenant_id,
+        "subscriptionId": subscription_id
+    }
+
+    resource_client = get_client(
+        ResourceManagementClient, config_dict
+    )
+
+    print('# searching for resource groups matching tag {}'.format(tag))
+    for resource_group in resource_client.resource_groups.list():
+        tags = resource_group.tags
+
+        if tags:
+            for tag_value in tags.values():
+                if tag_value.startswith(tag):
+                    resource_group_name = resource_group.name
+                    print('# deleting resource group: {}'.format(
+                        resource_group_name))
+                    result = resource_client.resource_groups.delete(
+                        resource_group_name=resource_group_name
+                    )
+                    result.wait()
+                    break
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    clean_azure(
+        tag=args.tag,
+        client_id=args.client_id,
+        client_secret=args.client_secret,
+        tenant_id=args.tenant_id,
+        subscription_id=args.subscription_id
+    )

--- a/ubuntu-advantage-client/azure_cleanup.py
+++ b/ubuntu-advantage-client/azure_cleanup.py
@@ -24,19 +24,19 @@ def parse_args():
             "Default: {}".format(CI_DEFAULT_TAG))
     )
     parser.add_argument(
-        "--client-id", dest="client_id", 
+        "--client-id", dest="client_id",
         help="Client id used to access azure api"
     )
     parser.add_argument(
-        "--client-secret", dest="client_secret", 
+        "--client-secret", dest="client_secret",
         help="Client secret used to access azure api"
     )
     parser.add_argument(
-        "--tenant-id", dest="tenant_id", 
+        "--tenant-id", dest="tenant_id",
         help="Tenant id used to access azure api"
     )
     parser.add_argument(
-        "--subscription-id", dest="subscription_id", 
+        "--subscription-id", dest="subscription_id",
         help="Subscription id used to access azure api"
     )
     parser.add_argument(
@@ -74,8 +74,8 @@ def clean_azure(tag, client_id, client_secret, tenant_id, subscription_id):
             for tag_value in tags.values():
                 if tag_value.startswith(tag):
                     resource_group_name = resource_group.name
-                    print('# deleting resource group: {}'.format(
-                        resource_group_name))
+                    print('# deleted resource group: {} with tag {}'.format(
+                        resource_group_name, tag))
                     result = resource_client.resource_groups.delete(
                         resource_group_name=resource_group_name
                     )

--- a/ubuntu-advantage-client/azure_cleanup.py
+++ b/ubuntu-advantage-client/azure_cleanup.py
@@ -85,7 +85,14 @@ def clean_azure(tag, client_id, client_secret, tenant_id, subscription_id):
 
 def load_azure_config(credentials_file):
     with open(credentials_file, 'r') as f:
-        return json.load(f)
+        all_credentials = json.load(f)
+
+        return {
+            "client_id": all_credentials["clientId"],
+            "client_secret": all_credentials["clientSecret"],
+            "tenant_id": all_credentials["tenantId"],
+            "subscription_id": all_credentials["subscriptionId"]
+        }
 
 
 if __name__ == '__main__':

--- a/ubuntu-advantage-client/azure_cleanup.py
+++ b/ubuntu-advantage-client/azure_cleanup.py
@@ -40,9 +40,9 @@ def parse_args():
         help="Subscription id used to access azure api"
     )
     parser.add_argument(
-        "--credentials-path", dest="credentials_path",
+        "--credentials-file", dest="credentials_file",
         help="""
-            Path where the credentials file is stored. That file must a be
+            Json file representing the Azure credentials. That file must a be
             a json dict containing all the necessary credentials to manage
             Azure resources. To successfuly be used in this script,
             the json file must have the following keys:  client_id,
@@ -83,22 +83,25 @@ def clean_azure(tag, client_id, client_secret, tenant_id, subscription_id):
                     break
 
 
-def load_azure_config(credentials_path):
-    with open(credentials_path, 'r') as f:
+def load_azure_config(credentials_file):
+    with open(credentials_file, 'r') as f:
         return json.load(f)
 
 
 if __name__ == '__main__':
     args = parse_args()
-    if args.credentials_path:
-        if os.path.exists(args.credentials_path):
-            config_dict = load_azure_config(
-                args.credentials_path
-            )
-            clean_azure(
-                tag=args.tag,
-                **config_dict
-            )
+    if args.credentials_file:
+        if not os.path.exists(args.credentials_file):
+            raise Exception("File {} could not be found".format(
+                args.credentials_file))
+
+        config_dict = load_azure_config(
+            args.credentials_file
+        )
+        clean_azure(
+            tag=args.tag,
+            **config_dict
+        )
     else:
         clean_azure(
             tag=args.tag,


### PR DESCRIPTION
This script cleans up all resource associated with a resource group associated with a given tag.
It will be called by either a travis job at the end of each test run or through a separate daily jenkins job.