### PR TITLE
copr_test: always disable non-baseurl mirrors when using a proxy

### DIFF
--- a/cloud-init/copr_test
+++ b/cloud-init/copr_test
@@ -72,8 +72,8 @@ start_container() {
     if [ ! -z "${http_proxy-}" ]; then
         debug 1 "configuring proxy ${http_proxy}"
         inside "$name" sh -c "echo proxy=$http_proxy >> /etc/yum.conf"
-        inside "$name" sed -i s/enabled=1/enabled=0/ /etc/yum/pluginconf.d/fastestmirror.conf
-        inside "$name" sh -c "sed -i '/^#baseurl=/s/#// ; s/^mirrorlist/#mirrorlist/' /etc/yum.repos.d/*.repo"
+        inside "$name" sh -c "sed -i --regexp-extended '/^#baseurl=/s/#// ; /^(mirrorlist|metalink)=/s/^/#/' /etc/yum.repos.d/*.repo"
+        inside "$name" sh -c "sed -i 's/download\.fedoraproject\.org/dl.fedoraproject.org/g' /etc/yum.repos.d/*.repo"
     fi
 }
 
@@ -95,6 +95,11 @@ install_pkgs() {
        sleep $nap
     done
     inside "$name" yum install --cacheonly --assumeyes "$@"
+    if inside "$name" grep -q "^proxy=" /etc/yum.conf; then
+        debug 1 "http proxy in use => forcing the use of fixed URLs in /etc/yum.repos.d/*.repo"
+        inside "$name" sh -c "sed -i --regexp-extended '/^#baseurl=/s/#// ; /^(mirrorlist|metalink)=/s/^/#/' /etc/yum.repos.d/*.repo"
+        inside "$name" sh -c "sed -i 's/download\.fedoraproject\.org/dl.fedoraproject.org/g' /etc/yum.repos.d/*.repo"
+    fi
 }
 
 delete_container() {


### PR DESCRIPTION
When using an http proxy make sure to disable all the dynamic mirror
URLs. In particular:

 - Uncomment the baseurl in /etc/yum.repos.d/*.repo.
 - Comment out the mirrorlist and metalink URLs in *.repo.
 - Replace the dynamic download.fedoraproject.org host with
   dl.fedoraproject.org, which is static.
 - Run the above as part of the install_pkgs() function, as installing
   packages may add new repos (e.g. EPEL).
 - Stop disabling fastestmirror, not needed when doing the above.

This is similar to:

https://github.com/canonical/cloud-init/commit/d4639837ff623f199afd3e44aa836bf4b845456e