### PR TITLE
Update azure_cleanup script

### DIFF
--- a/ubuntu-advantage-client/azure_cleanup.py
+++ b/ubuntu-advantage-client/azure_cleanup.py
@@ -19,10 +19,15 @@ CI_DEFAULT_TAG = "uaclient"
 def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "-t", "--tag", dest="tag", action="store", default=CI_DEFAULT_TAG,
+        "-pt", "--prefix-tag", dest="tag", action="store",
+        default=CI_DEFAULT_TAG,
         help=(
             "Tag used as a prefix to search for resources to be deleted."
             "Default: {}".format(CI_DEFAULT_TAG))
+    )
+    parser.add_argument(
+        "-st", "--suffix-tag", dest="tag", action="store",
+        help=("Tag used as a suffix to search for resources to be deleted.")
     )
     parser.add_argument(
         "--client-id", dest="client_id",
@@ -54,7 +59,17 @@ def get_parser():
     return parser
 
 
-def clean_azure(tag, client_id, client_secret, tenant_id, subscription_id):
+def check_tag(tag, prefix_tag, end_tag):
+    """Check for a match in the tag using both prefix_tag and end_tag"""
+    prefix_check = tag.startswith(prefix_tag)
+
+    if end_tag:
+        prefix_check &= tag.endswith(end_tag)
+
+    return prefix_check
+
+
+def clean_azure(prefix_tag, end_tag, client_id, client_secret, tenant_id, subscription_id):
     """Clean up all running Azure resources and resource groups"""
     config_dict = {
         "clientId": client_id,
@@ -73,7 +88,7 @@ def clean_azure(tag, client_id, client_secret, tenant_id, subscription_id):
 
         if tags:
             for tag_value in tags.values():
-                if tag_value.startswith(tag):
+                if check_tag(tag, prefix_tag, end_tag):
                     resource_group_name = resource_group.name
                     print('# deleted resource group: {} with tag {}'.format(
                         resource_group_name, tag))
@@ -119,7 +134,8 @@ if __name__ == '__main__':
             args.credentials_file
         )
         clean_azure(
-            tag=args.tag,
+            prefix_tag=args.prefix_tag,
+            suffix_tag=args.suffix_tag,
             **config_dict
         )
     else:


### PR DESCRIPTION
Right now, we are trying to use the `azure_cleanup` script in uaclient. However, this scrips was coded with the intention of removing all of the `resource_groups` at the end of all tests. Currently, we intend to run this script after each test has finished. To do that, we must updated how we perform the tag matching in this script