### PR TITLE
LMA: Don't grep for 'runtime-config' on cortex_test.sh

### DIFF
--- a/lma-integration/tests/cortex_test.sh
+++ b/lma-integration/tests/cortex_test.sh
@@ -14,8 +14,6 @@ test_services_status() {
   assertTrue $?
   echo $response | grep -A1 store | grep Running > /dev/null
   assertTrue $?
-  echo $response | grep -A1 runtime-config | grep Running > /dev/null
-  assertTrue $?
   echo $response | grep -A1 table-manager | grep Running > /dev/null
   assertTrue $?
   echo $response | grep -A1 query-frontend | grep Running > /dev/null


### PR DESCRIPTION
The 'runtime-config' excerpt shows up in the output of
'$cortex_url/services' when we invoke cortex using the
'--runtime-config.file' option.  The runtime config file is something
we can provide to the cortex binary that allows us to change the
service configuration on-the-fly.

At the moment, we do not start cortex using this option.  For this
reason, it doesn't make sense for us to try to grep for this option in
the output.  This commit removes the grep, which makes the test
finally pass 100%.