### PR TITLE
LMA: Containerize the test infrastructure

### DIFF
--- a/lma-integration/README
+++ b/lma-integration/README
@@ -1,9 +1,13 @@
 # Integration tests for the LMA stack
 
-How to run tests:
+How to run tests locally:
 
-$ apt-get install -y docker.io docker-compose shunit2 curl
+$ apt-get install -y docker.io docker-compose
 $ ./run-tests
+
+You can also run the tests inside a VM by doing:
+
+$ ./lxd-runner
 
 The tests will bind the services to the following ports:
 

--- a/lma-integration/config/alertmanager.yml
+++ b/lma-integration/config/alertmanager.yml
@@ -7,10 +7,12 @@ route:
   group_interval: 10s
   repeat_interval: 1h
   receiver: 'webhook-test'
+
 receivers:
 - name: 'webhook-test'
   webhook_configs:
-  - url: 'http://127.0.0.1:5001/'
+  - url: 'http://tests:5001/'
+
 inhibit_rules:
   - source_match:
       severity: 'critical'

--- a/lma-integration/config/cortex.yaml
+++ b/lma-integration/config/cortex.yaml
@@ -41,7 +41,7 @@ ingester:
   lifecycler:
     # The address to advertise for this ingester.  Will be autodiscovered by
     # looking up address on eth0 or en0; can be specified if this fails.
-    address: 127.0.0.1
+    address: 0.0.0.0
 
     # We want to start immediately and flush on shutdown.
     join_after: 0

--- a/lma-integration/config/grafana/provisioning/datasources/datasource.yml
+++ b/lma-integration/config/grafana/provisioning/datasources/datasource.yml
@@ -5,7 +5,7 @@ datasources:
     type: prometheus
     access: proxy
     orgId: 1
-    url: http://127.0.0.1:9009/api/prom
+    url: http://cortex:9009/api/prom
     basicAuth: false
     isDefault: true
     editable: true

--- a/lma-integration/config/prometheus.yml
+++ b/lma-integration/config/prometheus.yml
@@ -9,7 +9,7 @@ alerting:
   alertmanagers:
   - static_configs:
     - targets:
-      - 127.0.0.1:9093
+      - alertmanager:9093
 
 # Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
 rule_files:
@@ -27,16 +27,16 @@ scrape_configs:
     # scheme defaults to 'http'.
 
     static_configs:
-    - targets: ['localhost:9090']
+    - targets: ['prometheus:9090']
 
   - job_name: 'node-exporter'
     static_configs:
-    - targets: ['127.0.0.1:9100']
+    - targets: ['node-exporter:9100']
 
   - job_name: 'telegraf'
     static_configs:
-    - targets: ['127.0.0.1:9273']
+    - targets: ['telegraf:9273']
 
 remote_write:
-  - url: http://127.0.0.1:9009/api/prom/push
+  - url: http://cortex:9009/api/prom/push
 

--- a/lma-integration/config/telegraf.conf
+++ b/lma-integration/config/telegraf.conf
@@ -666,10 +666,10 @@
  # A plugin that can transmit metrics over HTTP
  [[outputs.http]]
    ## URL is the address to send metrics to
-   url = "http://127.0.0.1:8080/"
+   url = "http://tests:8080/"
 
    ## Timeout for HTTP message
-   # timeout = "5s"
+   timeout = "2s"
 
    ## HTTP method, one of: "POST" or "PUT"
    # method = "POST"
@@ -1120,7 +1120,7 @@
  # Configuration for the Prometheus client to spawn
  [[outputs.prometheus_client]]
    ## Address to listen on
-   listen = "127.0.0.1:9273"
+   listen = "0.0.0.0:9273"
 
    ## Metric version controls the mapping from Telegraf metrics into
    ## Prometheus format.  When using the prometheus input, use the same value in

--- a/lma-integration/docker-compose.yml
+++ b/lma-integration/docker-compose.yml
@@ -1,48 +1,52 @@
-version: '2'
+version: '3'
 
 services:
     prometheus:
         image: squeakywheel/prometheus:edge
-        network_mode: "host"
         ports:
             - 9090:9090
         volumes:
             - ./config/prometheus.yml:/etc/prometheus/prometheus.yml
             - ./config/alerts.yml:/etc/prometheus/alerts.yml
+        networks:
+            - lmatest
 
     node-exporter:
         image: prom/node-exporter
-        network_mode: "host"
         ports:
             - 9100:9100
+        networks:
+            - lmatest
 
     telegraf:
         image: squeakywheel/telegraf:edge
-        network_mode: "host"
         ports:
             - 9273:9273
         volumes:
             - ./config/telegraf.conf:/etc/telegraf/telegraf.conf
+        networks:
+            - lmatest
 
     alertmanager:
         image: squeakywheel/prometheus-alertmanager:edge
-        network_mode: "host"
         ports:
             - 9093:9093
         volumes:
-            - ./config/alertmanager.yml:/etc/prometheus/alertmanager.yml
+            - ./config/alertmanager.yml:/etc/alertmanager/alertmanager.yml
+        networks:
+            - lmatest
 
     grafana:
         image: squeakywheel/grafana:edge
-        network_mode: "host"
         ports:
             - 3000:3000
         volumes:
             - ./config/grafana/provisioning/:/etc/grafana/provisioning/
+        networks:
+            - lmatest
 
     cortex:
         image: squeakywheel/cortex:edge
-        network_mode: "host"
         ports:
             - 9009:9009
         volumes:
@@ -50,3 +54,17 @@ services:
         command: [
             "-config.file=/etc/cortex/cortex.yaml"
             ]
+        networks:
+            - lmatest
+
+    tests:
+        image: squeakywheel/lma-integration-tests
+        ports:
+            - 5001:5001
+            - 8080:8080
+        networks:
+            - lmatest
+
+networks:
+    lmatest:
+        driver: bridge

--- a/lma-integration/run-tests
+++ b/lma-integration/run-tests
@@ -1,23 +1,36 @@
-#!/bin/sh
+#!/bin/bash
 
-set -e
+# We want the main docker-compose process to exit with the same code
+# as the "tests" container.  For this reason, we use
+# '--exit-code-from', which implies that we cannot detach from the
+# containers.
+#
+# To avoid polluting the terminal with a bunch of logs from the
+# containers, we redirect stdout to /dev/null and put
+# docker-compose in the background.
+docker-compose up --abort-on-container-exit --exit-code-from tests > /dev/null &
 
-# set up containers
-docker-compose up -d
-sleep 5
+# We will need the process' PID to check for the exit status later.
+docker_compose_pid=$!
 
-# run tests
-failed=0
-for file in tests/*_test.sh; do
-  rc=0
-  echo "$file"
-  mispipe "sh $file" "sed -e 's/ASSERT:/FAILED:/; s/^/  /'" || rc=$?
-  if [ $rc -ne 0 ]; then
-    failed=1
-  fi
+echo "Waiting until the test container becomes available..."
+
+# This is a trick needed to "wait" until the "tests" container is
+# ready to be attached to.
+while [ "$(docker-compose ps -q tests 2> /dev/null)" = "" ]; do
+    sleep 0.5
 done
 
-# stop containers
+# Attach to the "tests" container and print its logs.  These are the
+# actual test results.
+docker-compose logs -f tests
+
+# Time to wait until the first docker-compose process finishes, so we
+# can grab its exit code.
+wait $docker_compose_pid
+exit_code=$?
+
+# Clean up after ourselves.
 docker-compose down
 
-exit $failed
+exit $exit_code

--- a/lma-integration/tests/Dockerfile
+++ b/lma-integration/tests/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:groovy
+
+RUN set -eux; \
+	apt-get update \
+	&& DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
+	&& DEBIAN_FRONTEND=noninteractive apt-get install shunit2 curl moreutils netcat-openbsd -y \
+	&& rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tests
+COPY . .
+
+ENTRYPOINT [ "/tests/tests.sh" ]

--- a/lma-integration/tests/alertmanager_test.sh
+++ b/lma-integration/tests/alertmanager_test.sh
@@ -32,7 +32,7 @@ EOF
 
 test_web_hook_call() {
   # the webhook is configured to send a request to localhost port 5001
-  response=$(nc -l -p 5001)
+  response=$(timeout 20s nc -l 0.0.0.0 5001)
 
   echo $response | grep User-Agent | grep Alertmanager > /dev/null
   assertTrue $?

--- a/lma-integration/tests/globals.sh
+++ b/lma-integration/tests/globals.sh
@@ -1,0 +1,7 @@
+# export some global variables
+export prometheus_url="http://prometheus:9090"
+export alertmanager_url="http://alertmanager:9093"
+export telegraf_url="http://telegraf:9273"
+export cortex_url="http://cortex:9009"
+# Grafana requires credentials which is user admin and password admin
+export grafana_url="http://admin:admin@grafana:3000"

--- a/lma-integration/tests/helper/test_helper.sh
+++ b/lma-integration/tests/helper/test_helper.sh
@@ -9,10 +9,4 @@ load_shunit2() {
   fi
 }
 
-# export some global variables
-export prometheus_url="http://127.0.0.1:9090"
-export alertmanager_url="http://127.0.0.1:9093"
-export telegraf_url="http://127.0.0.1:9273"
-export cortex_url="http://127.0.0.1:9009"
-# Grafana requires credentials which is user admin and password admin
-export grafana_url="http://admin:admin@127.0.0.1:3000"
+. $(dirname $0)/globals.sh

--- a/lma-integration/tests/telegraf_test.sh
+++ b/lma-integration/tests/telegraf_test.sh
@@ -12,7 +12,7 @@ test_prometheus_output() {
 
 test_http_output() {
   # the http output is configured to send the data to localhost port 8080
-  response=$(nc -w 20 -l -p 8080)
+  response=$(timeout 20s nc -l 0.0.0.0 8080)
 
   echo $response | grep diskio > /dev/null
   assertTrue $?

--- a/lma-integration/tests/tests.sh
+++ b/lma-integration/tests/tests.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+. $(dirname $0)/globals.sh
+
+wait_for_services ()
+{
+    local urls=( $prometheus_url
+		 $alertmanager_url
+		 $telegraf_url
+		 $cortex_url
+		 $grafana_url )
+
+    echo "Waiting for all the services to be online..."
+    for url in ${urls[@]}; do
+	while ! curl --silent --output /dev/null $url; do
+	    sleep 1
+	done
+    done
+}
+
+# We must wait until all services are available.
+wait_for_services
+
+# run tests
+failed=0
+for file in /tests/*_test.sh; do
+  rc=0
+  echo "$file"
+  mispipe "sh $file" "sed -e 's/ASSERT:/FAILED:/; s/^/  /'" || rc=$?
+  if [ $rc -ne 0 ]; then
+    failed=1
+  fi
+done
+
+exit $failed


### PR DESCRIPTION
This series of commits implement the "test containerization" idea that
Lucas told me about.

The gist of it is that the tests will now be executed from inside
another container (which is part of the docker-compose group of
containers), which means that all the communication between the
containers (and therefore the services) will take place using the
internal network that docker-compose will create, instead of
localhost.

It took me some time to adjust the scripts and make them properly
print only the test results.  In the end, I think I've reached a
compromise that is decent enough while avoiding printing too much
pollution from logs.  Here's the full output when you invoke
`./run-tests.sh`:

```
Waiting until the test container becomes available...
Creating network "lma-integration_default" with the default driver
Creating lma-integration_cortex_1 ... 
Creating lma-integration_node-exporter_1 ... 
Creating lma-integration_alertmanager_1  ... 
Creating lma-integration_grafana_1       ... 
Creating lma-integration_telegraf_1      ... 
Creating lma-integration_tests_1         ... 
Creating lma-integration_prometheus_1    ... 
Creating lma-integration_alertmanager_1  ... done
Creating lma-integration_telegraf_1      ... done
Creating lma-integration_prometheus_1    ... done
Creating lma-integration_node-exporter_1 ... done
Creating lma-integration_cortex_1        ... done
Creating lma-integration_grafana_1       ... done
Creating lma-integration_tests_1         ... done
Attaching to lma-integration_tests_1
tests_1          | Waiting for all the services to be online...
tests_1          | /tests/alertmanager_test.sh
tests_1          |   test_web_interface_is_up
tests_1          |   test_fire_an_alert
tests_1          |   test_web_hook_call
tests_1          |   FAILED:
tests_1          |   FAILED:
tests_1          |   FAILED:
tests_1          |   
tests_1          |   Ran 3 tests.
tests_1          |   
tests_1          |   FAILED (failures=3)
tests_1          | /tests/cortex_test.sh
tests_1          |   test_api_is_up
tests_1          |   test_services_status
tests_1          |   
tests_1          |   Ran 2 tests.
tests_1          |   
tests_1          |   OK
tests_1          | /tests/grafana_test.sh
tests_1          |   test_datasource
tests_1          |   test_dashboard
tests_1          |   
tests_1          |   Ran 2 tests.
tests_1          |   
tests_1          |   OK
tests_1          | /tests/prometheus_test.sh
tests_1          |   test_web_interface_is_up
tests_1          |   test_configuration_is_loaded
tests_1          |   test_targets
tests_1          |   test_alertmanager
tests_1          |   test_registered_alerts
tests_1          |   
tests_1          |   Ran 5 tests.
tests_1          |   
tests_1          |   OK
tests_1          | /tests/telegraf_test.sh
tests_1          |   test_prometheus_output
tests_1          |   test_http_output
tests_1          |   
tests_1          |   Ran 2 tests.
tests_1          |   
tests_1          |   OK
lma-integration_tests_1 exited with code 1
Stopping lma-integration_prometheus_1    ... 
Stopping lma-integration_grafana_1       ... 
Stopping lma-integration_telegraf_1      ... 
Stopping lma-integration_cortex_1        ... 
Stopping lma-integration_alertmanager_1  ... 
Stopping lma-integration_node-exporter_1 ... 
Stopping lma-integration_alertmanager_1  ... done
Stopping lma-integration_node-exporter_1 ... done
Stopping lma-integration_prometheus_1    ... done
Stopping lma-integration_cortex_1        ... done
Removing lma-integration_prometheus_1    ... 
Removing lma-integration_grafana_1       ... 
Removing lma-integration_telegraf_1      ... 
Removing lma-integration_tests_1         ... 
Removing lma-integration_cortex_1        ... 
Removing lma-integration_alertmanager_1  ... 
Removing lma-integration_node-exporter_1 ... 
Removing lma-integration_alertmanager_1  ... done
Removing lma-integration_prometheus_1    ... done
Removing lma-integration_cortex_1        ... done
Removing network lma-integration_default
```

Bear in mind that the failures we see above have already been reported
at https://github.com/prometheus/alertmanager/issues/2399.

The script exits with status code 0 if everything succeeded, or 1 if
anything failed.  I tested it with the `lxd-runner` script, and it
also works OK.