### PR TITLE
OCI unit tests: Use psql from container

### DIFF
--- a/oci-unit-tests/postgresql_test.sh
+++ b/oci-unit-tests/postgresql_test.sh
@@ -8,10 +8,20 @@
 #  setUp() - run before each test
 #  tearDown() - run after each test
 
+DOCKER_NETWORK_NAME=postgresql_test
+
+oneTimeSetUp() {
+    docker network create $DOCKER_NETWORK_NAME > /dev/null 2>&1
+}
+
 setUp() {
     password=$(dd if=/dev/urandom bs=1 count=16 2>/dev/null | md5sum | head -c 16)
     id=$$
     image="squeakywheel/postgres:edge"
+}
+
+oneTimeTearDown() {
+    docker network rm $DOCKER_NETWORK_NAME > /dev/null 2>&1
 }
 
 tearDown() {
@@ -37,7 +47,9 @@ test_set_admin_user() {
 # it is not specified, then the default user of postgres will be used.
     admin_user="user${id}"
     debug "Creating container with POSTGRES_USER=${admin_user}"
-    container=$(docker run --rm -d \
+    container=$(docker run \
+        --network $DOCKER_NETWORK_NAME \
+        --rm -d \
         -e POSTGRES_USER=${admin_user} \
         -e POSTGRES_PASSWORD=${password} \
         -p 5432:5432 \
@@ -48,16 +60,28 @@ test_set_admin_user() {
     wait_postgres_container_ready "${container}" || return 1
     debug "Testing connection as ${admin_user}, looking for \"postgres\" DB"
     # default db is still "postgres"
-    out=$(psql postgresql://${admin_user}:${password}@127.0.0.1 -q -l -A -t -F % | grep "^postgres" | cut -d % -f 1)
+    out=$(docker run \
+              --network $DOCKER_NETWORK_NAME \
+              --rm \
+              ${image} \
+              psql postgresql://${admin_user}:${password}@postgresql_test_${id} -q -l -A -t -F % | grep "^postgres" | cut -d % -f 1)
     assertEquals "DB listing did not include \"postgres\"" postgres "${out}" || return 1
     # Verify we can create a new DB, since we are an admin
     test_db="test_db${id}"
     debug "Trying to create a new DB called ${test_db} as user ${admin_user}"
-    psql postgresql://${admin_user}:${password}@127.0.0.1 -q -c \
+    docker run \
+        --network $DOCKER_NETWORK_NAME \
+        --rm \
+        ${image} \
+        psql postgresql://${admin_user}:${password}@postgresql_test_${id} -q -c \
         "CREATE DATABASE ${test_db};"
     # list DB
     debug "Verifying DB ${test_db} was created"
-    out=$(psql postgresql://${admin_user}:${password}@127.0.0.1 -q -l -A -t -F % | grep "^${test_db}" | cut -d % -f 1)
+    out=$(docker run \
+              --network $DOCKER_NETWORK_NAME \
+              --rm \
+              ${image} \
+              psql postgresql://${admin_user}:${password}@postgresql_test_${id} -q -l -A -t -F % | grep "^${test_db}" | cut -d % -f 1)
     assertEquals "DB listing did not include \"postgres\"" "${test_db}" "${out}" || return 1
 }
 
@@ -68,7 +92,9 @@ test_default_database_name() {
 # is not specified, then the value of POSTGRES_USER will be used.
     test_db="database${id}"
     debug "Creating container with POSTGRES_DB=${test_db}"
-    container=$(docker run --rm -d \
+    container=$(docker run \
+        --network $DOCKER_NETWORK_NAME \
+        --rm -d \
         -e POSTGRES_DB=${test_db} \
         -e POSTGRES_PASSWORD=${password} \
         -p 5432:5432 \
@@ -78,7 +104,11 @@ test_default_database_name() {
     assertNotNull "Failed to start the container" "${container}" || return 1
     wait_postgres_container_ready "${container}" || return 1
     debug "Checking if database ${test_db} was created"
-    out=$(psql postgresql://postgres:${password}@127.0.0.1 -q -l -A -t -F % | grep "^${test_db}" | cut -d % -f 1)
+    out=$(docker run \
+              --network $DOCKER_NETWORK_NAME \
+              --rm \
+              ${image} \
+              psql postgresql://postgres:${password}@postgresql_test_${id} -q -l -A -t -F % | grep "^${test_db}" | cut -d % -f 1)
     assertEquals "Failed to create test database" "${test_db}" "${out}" || return 1
 }
 
@@ -89,7 +119,9 @@ test_persistent_volume_keeps_changes() {
     volume=$(docker volume create)
     assertNotNull "Failed to create a volume" "${volume}" || return 1
     debug "Launching container"
-    container=$(docker run --rm -d \
+    container=$(docker run \
+        --network $DOCKER_NETWORK_NAME \
+        --rm -d \
         -e POSTGRES_PASSWORD=${password} \
         -p 5432:5432 \
         --mount source=${volume},target=/var/lib/postgresql/data \
@@ -103,20 +135,34 @@ test_persistent_volume_keeps_changes() {
     # Create test database
     test_db="test_db_${id}"
     debug "Creating test database ${test_db}"
-    psql postgresql://postgres:${password}@127.0.0.1/postgres -q -c \
+    docker run \
+        --network $DOCKER_NETWORK_NAME \
+        --rm \
+        ${image} \
+        psql postgresql://postgres:${password}@postgresql_test_${id}/postgres -q -c \
         "CREATE DATABASE ${test_db};"
-    out=$(psql postgresql://postgres:${password}@127.0.0.1 -q -l -A -t -F % | grep "^${test_db}" | cut -d % -f 1)
+    out=$(docker run \
+              --network $DOCKER_NETWORK_NAME \
+              --rm \
+              ${image} \
+              psql postgresql://postgres:${password}@postgresql_test_${id} -q -l -A -t -F % | grep "^${test_db}" | cut -d % -f 1)
     assertEquals "Failed to create test database" "${test_db}" "${out}" || return 1
 
     # create test table
     test_table="test_data_${id}"
     debug "Creating test table ${test_table} with data"
-    psql postgresql://postgres:${password}@127.0.0.1/${test_db} -q <<EOF
-CREATE TABLE ${test_table} (id INT, description TEXT);
-INSERT INTO ${test_table} (id,description) VALUES (${id}, 'hello');
-EOF
-    out=$(psql -F % -A -t postgresql://postgres:${password}@127.0.0.1/${test_db} -q -c \
-        "SELECT * FROM ${test_table};")
+    docker run \
+        --network $DOCKER_NETWORK_NAME \
+        --rm \
+        ${image} \
+        psql postgresql://postgres:${password}@postgresql_test_${id}/${test_db} -q -c \
+        "CREATE TABLE ${test_table} (id INT, description TEXT); INSERT INTO ${test_table} (id,description) VALUES (${id}, 'hello');"
+    out=$(docker run \
+              --network $DOCKER_NETWORK_NAME \
+              --rm \
+              ${image} \
+              psql -F % -A -t postgresql://postgres:${password}@postgresql_test_${id}/${test_db} -q -c \
+              "SELECT * FROM ${test_table};")
     assertEquals "Failed to verify test table" "${id}%hello" "${out}" || return 1
 
     # stop container, which deletes it because it was launched with --rm
@@ -126,7 +172,9 @@ EOF
     # By using the same --name also makes sure the previous container is really
     # gone, otherwise the new one wouldn't start
     debug "Launching new container with same volume"
-    container=$(docker run --rm -d \
+    container=$(docker run \
+        --network $DOCKER_NETWORK_NAME \
+        --rm -d \
         -p 5432:5432 \
         --mount source=${volume},target=/var/lib/postgresql/data \
         --name postgresql_test_${id} \
@@ -136,8 +184,12 @@ EOF
     wait_container_ready "${container}" "${ready_log}"
     # data we created previously should still be there
     debug "Verifying database ${test_db} and table ${test_table} are there with our data"
-    out=$(psql -F % -A -t postgresql://postgres:${password}@127.0.0.1/${test_db} -q -c \
-        "SELECT * FROM ${test_table};")
+    out=$(docker run \
+              --network $DOCKER_NETWORK_NAME \
+              --rm \
+              ${image} \
+              psql -F % -A -t postgresql://postgres:${password}@postgresql_test_${id}/${test_db} -q -c \
+              "SELECT * FROM ${test_table};")
     assertEquals "Failed to verify test table" "${id}%hello" "${out}" || return 1
 }
 


### PR DESCRIPTION
This commit is based on Andrea's suggestion from PR #60.  Instead of
relying on the host's psql binary, we can (and indeed should!) use the
container's psql.  This has a bunch of positive points:

- It makes it unnecessary to install test dependencies on the host.

- It exercises the psql from inside the container, which is software
  that we will ship to the users anyway.

- It uses non-localhost hostnames for the tests (albeit we'd still
  be using a local docker network bridge).

The only "drawback" (if you can say so) is that it's not really
feasible to use here-document when invoking psql anymore, but this is
really not very significant for our purposes.

I've made sure the tests are still passing, and I don't have psql
installed in the host machine.