### PR TITLE
oci test_helper: bump the container timeout to 30s

### DIFF
--- a/oci-unit-tests/helper/test_helper.sh
+++ b/oci-unit-tests/helper/test_helper.sh
@@ -40,11 +40,11 @@ stop_container_sync() {
 
 # $1: container id
 # $2: last message to look for in logs
-# $3: timeout (optional).  If not specified, defaults to 5 seconds
+# $3: timeout (optional).  If not specified, defaults to 30 seconds
 wait_container_ready() {
     local id="${1}"
     local msg="${2}"
-    local timeout="${3:-5}"
+    local timeout="${3:-30}"
     local logs
     local max=${timeout}
 


### PR DESCRIPTION
5 seconds are very often not enough, at least not on busy Jenkins nodes.
Let's bump it to a default that will work most of the time while also
being reasonably low.