### PR TITLE
OCI unit tests: Make sure we're using the latest OCI image

### DIFF
--- a/oci-unit-tests/alertmanager_test.sh
+++ b/oci-unit-tests/alertmanager_test.sh
@@ -18,6 +18,9 @@ readonly DOCKER_IMAGE="squeakywheel/prometheus-alertmanager:edge"
 readonly ALERTMANAGER_PORT=60001
 
 oneTimeSetUp() {
+    # Make sure we're using the latest OCI image.
+    docker pull --quiet "$DOCKER_IMAGE" > /dev/null
+
     # Cleanup stale resources
     tearDown
 }

--- a/oci-unit-tests/apache2_test.sh
+++ b/oci-unit-tests/apache2_test.sh
@@ -18,6 +18,9 @@ readonly DOCKER_IMAGE="squeakywheel/apache2:edge"
 readonly LOCAL_PORT=59080
 
 oneTimeSetUp() {
+    # Make sure we're using the latest OCI image.
+    docker pull --quiet "$DOCKER_IMAGE" > /dev/null
+
     # Cleanup stale resources
     tearDown
 }

--- a/oci-unit-tests/cortex_test.sh
+++ b/oci-unit-tests/cortex_test.sh
@@ -18,6 +18,9 @@ readonly DOCKER_IMAGE="squeakywheel/cortex:edge"
 readonly CORTEX_PORT=60009
 
 oneTimeSetUp() {
+    # Make sure we're using the latest OCI image.
+    docker pull --quiet "$DOCKER_IMAGE" > /dev/null
+
     # Cleanup stale resources
     tearDown
 }

--- a/oci-unit-tests/memcached_test.sh
+++ b/oci-unit-tests/memcached_test.sh
@@ -18,6 +18,9 @@ readonly DOCKER_NETWORK="${DOCKER_PREFIX}_network"
 readonly DOCKER_IMAGE="squeakywheel/memcached:edge"
 
 oneTimeSetUp() {
+    # Make sure we're using the latest OCI image.
+    docker pull --quiet "$DOCKER_IMAGE" > /dev/null
+
     # Cleanup stale resources
     tearDown
     oneTimeTearDown

--- a/oci-unit-tests/mysql_test.sh
+++ b/oci-unit-tests/mysql_test.sh
@@ -14,6 +14,9 @@ readonly DOCKER_NETWORK=mysql_test
 readonly DOCKER_IMAGE="squeakywheel/mysql:edge"
 
 oneTimeSetUp() {
+    # Make sure we're using the latest OCI image.
+    docker pull --quiet "$DOCKER_IMAGE" > /dev/null
+
     docker network create $DOCKER_NETWORK > /dev/null 2>&1
 }
 

--- a/oci-unit-tests/nginx_test.sh
+++ b/oci-unit-tests/nginx_test.sh
@@ -18,6 +18,9 @@ readonly DOCKER_NETWORK="${DOCKER_PREFIX}_network"
 readonly DOCKER_IMAGE="squeakywheel/nginx:edge"
 
 oneTimeSetUp() {
+    # Make sure we're using the latest OCI image.
+    docker pull --quiet "$DOCKER_IMAGE" > /dev/null
+
     # Cleanup stale resources
     tearDown
     oneTimeTearDown

--- a/oci-unit-tests/postgresql_test.sh
+++ b/oci-unit-tests/postgresql_test.sh
@@ -11,6 +11,9 @@
 DOCKER_NETWORK_NAME=postgresql_test
 
 oneTimeSetUp() {
+    # Make sure we're using the latest OCI image.
+    docker pull --quiet "$DOCKER_IMAGE" > /dev/null
+
     docker network create $DOCKER_NETWORK_NAME > /dev/null 2>&1
 }
 

--- a/oci-unit-tests/prometheus_test.sh
+++ b/oci-unit-tests/prometheus_test.sh
@@ -23,6 +23,9 @@ readonly ALERTMANAGER_PORT=50001
 readonly PUSHGATEWAY_PORT=50002
 
 oneTimeSetUp() {
+    # Make sure we're using the latest OCI image.
+    docker pull --quiet "$DOCKER_IMAGE" > /dev/null
+
     # Cleanup stale resources
     tearDown
     oneTimeTearDown

--- a/oci-unit-tests/redis_test.sh
+++ b/oci-unit-tests/redis_test.sh
@@ -14,6 +14,9 @@ readonly DOCKER_NETWORK=redis_test
 readonly DOCKER_IMAGE="squeakywheel/redis:edge"
 
 oneTimeSetUp() {
+    # Make sure we're using the latest OCI image.
+    docker pull --quiet "$DOCKER_IMAGE" > /dev/null
+
     docker network create $DOCKER_NETWORK > /dev/null 2>&1
 }
 

--- a/oci-unit-tests/telegraf_test.sh
+++ b/oci-unit-tests/telegraf_test.sh
@@ -16,6 +16,9 @@ readonly DOCKER_IMAGE="squeakywheel/telegraf:edge"
 readonly TELEGRAF_PORT=9273
 
 oneTimeSetUp() {
+    # Make sure we're using the latest OCI image.
+    docker pull --quiet "$DOCKER_IMAGE" > /dev/null
+
     # Cleanup stale resources
     tearDown
 }


### PR DESCRIPTION
In a discussion with Paride, we noticed that the OCI images can become
stale and are not automatically updated when there is a new version
available.  For this reason, it's better to call "docker pull
$DOCKER_IMAGE" every time we're starting a unittest.