### PR TITLE
azure_cleanup: flush the output stream in emit_dots stream to print during travis

### DIFF
--- a/ubuntu-advantage-client/azure_cleanup.py
+++ b/ubuntu-advantage-client/azure_cleanup.py
@@ -82,7 +82,7 @@ def emit_dots_on_travis():
 
     def emit_dots():
         while True:
-            print(".")
+            print(".", end="", flush=True)
             time.sleep(10)
 
     dot_process = multiprocessing.Process(target=emit_dots)


### PR DESCRIPTION
Otherwise we hit console output timeouts like the following:
https://travis-ci.com/github/canonical/ubuntu-advantage-client/jobs/439263319#L687-L691