### PR TITLE
OCI unit test: fix telegraf test

### DIFF
--- a/oci-unit-tests/helper/test_helper.sh
+++ b/oci-unit-tests/helper/test_helper.sh
@@ -50,20 +50,17 @@ wait_container_ready() {
     local id="${1}"
     local msg="${2}"
     local timeout="${3:-30}"
-    local logs
-    local max=${timeout}
+    local max=$timeout
 
     debug -n "Waiting for container to be ready "
-    logs=$(docker logs "${id}" --tail 1 2>&1)
-    while ! echo "${logs}" | grep -qE "${msg}"; do
-        debug -n "."
-        sleep 1
-		timeout=$((timeout-1))
-        if [ "${timeout}" -le 0 ]; then
-            fail "ERROR, failed to start container ${id} in ${max} seconds"
-            return 1
-        fi
-        logs=$(docker logs "${id}" --tail 1 2>&1)
+    while ! docker logs "${id}" 2>&1 | grep -qE "${msg}"; do
+	sleep 1
+	timeout=$((timeout - 1))
+	if [ $timeout -le 0 ]; then
+	    fail " ERROR, failed to start container ${id} in ${max} seconds"
+	    return 1
+	fi
+	debug -n "."
     done
-    debug
+    debug "done"
 }

--- a/oci-unit-tests/telegraf_test_data/telegraf.conf
+++ b/oci-unit-tests/telegraf_test_data/telegraf.conf
@@ -25,7 +25,7 @@
 # Configuration for telegraf agent
 [agent]
   ## Default data collection interval for all inputs
-  interval = "10s"
+  interval = "2s"
   ## Rounds collection interval to 'interval'
   ## ie, if interval="10s" then always collect on :00, :10, :20, etc.
   round_interval = true
@@ -1118,7 +1118,7 @@
 
 
  # Configuration for the Prometheus client to spawn
-# [[outputs.prometheus_client]]
+#[[outputs.prometheus_client]]
    ## Address to listen on
    #listen = "127.0.0.1:9273"
 


### PR DESCRIPTION
The telegraf unit test is unfortunately broken due to the way
assertTrue is being called.  I discovered this because the telegraf
OCI image was not configured by default to export the prometheus data
via its localhost:9273/metrics endpoint.

I fixed the image, and now I'm fixing the tests.  I'm also
implementing the idea discussed with Paride, which is to make
"wait_container_ready" accept a fourth argument allowing the caller to
grep for $msg in the full log message, and not only in the last line
of the log.

Last, but not least, I added descriptive messages to the assertTrue
tests.