### PR TITLE
Make lxd_cleanup script run on python 3.6

### DIFF
--- a/ubuntu-advantage-client/lxd_cleanup.py
+++ b/ubuntu-advantage-client/lxd_cleanup.py
@@ -5,7 +5,7 @@
 import argparse
 import datetime
 import json
-from subprocess import run
+from subprocess import run, PIPE
 
 DEFAULT_NAME_PREFIX = "ubuntu-behave-test"
 
@@ -35,7 +35,7 @@ if __name__ == '__main__':
         )
     else:
         before_date = datetime.datetime.today() - datetime.timedelta(days=1)
-    result = run(["lxc", "ls", "--format=json"], capture_output=True)
+    result = run(["lxc", "ls", "--format=json"], stdout=PIPE)
     if result.stdout:
         for instance in json.loads(result.stdout):
             if instance["name"].startswith(args.prefix):


### PR DESCRIPTION
Bionic is the release used on some of our Jenkins nodes.
Because of that, we need to make our scripts run on
python 3.6. This PR fixes that issue for the lxd cleanup script