### PR TITLE
Mysql test cleanup

### DIFF
--- a/oci-unit-tests/alertmanager_test.sh
+++ b/oci-unit-tests/alertmanager_test.sh
@@ -5,7 +5,7 @@
 
 # cheat sheet:
 #  assertTrue $?
-#  assertEquals 1 2
+#  assertEquals ["explanation"] 1 2
 #  oneTimeSetUp()
 #  oneTimeTearDown()
 #  setUp() - run before each test

--- a/oci-unit-tests/apache2_test.sh
+++ b/oci-unit-tests/apache2_test.sh
@@ -5,7 +5,7 @@
 
 # cheat sheet:
 #  assertTrue $?
-#  assertEquals 1 2
+#  assertEquals ["explanation"] 1 2
 #  oneTimeSetUp()
 #  oneTimeTearDown()
 #  setUp() - run before each test
@@ -79,7 +79,7 @@ test_static_content() {
     orig_checksum=$(md5sum "$test_data_wwwroot/test.txt" | awk '{ print $1 }')
     retrieved_checksum=$(curl -sS http://127.0.0.1:$LOCAL_PORT/test.txt | md5sum | awk '{ print $1 }')
 
-    assertEquals "${orig_checksum}" "${retrieved_checksum}"
+    assertEquals "Checksum mismatch in retrieved test.txt" "${orig_checksum}" "${retrieved_checksum}"
 }
 
 test_custom_config() {
@@ -94,7 +94,7 @@ test_custom_config() {
     orig_checksum=$(md5sum "$test_data_wwwroot/index.html" | awk '{ print $1 }')
     retrieved_checksum=$(curl -sS "http://127.0.0.1:$LOCAL_PORT" | md5sum | awk '{ print $1 }')
 
-    assertEquals "${orig_checksum}" "${retrieved_checksum}"
+    assertEquals "Checksum mismatch in retrieved index.hml" "${orig_checksum}" "${retrieved_checksum}"
 }
 
 

--- a/oci-unit-tests/cortex_test.sh
+++ b/oci-unit-tests/cortex_test.sh
@@ -5,7 +5,7 @@
 
 # cheat sheet:
 #  assertTrue $?
-#  assertEquals 1 2
+#  assertEquals ["explanation"] 1 2
 #  oneTimeSetUp()
 #  oneTimeTearDown()
 #  setUp() - run before each test

--- a/oci-unit-tests/grafana_test.sh
+++ b/oci-unit-tests/grafana_test.sh
@@ -5,7 +5,7 @@
 
 # cheat sheet:
 #  assertTrue $?
-#  assertEquals 1 2
+#  assertEquals ["explanation"] 1 2
 #  oneTimeSetUp()
 #  oneTimeTearDown()
 #  setUp() - run before each test

--- a/oci-unit-tests/memcached_test.sh
+++ b/oci-unit-tests/memcached_test.sh
@@ -5,7 +5,7 @@
 
 # cheat sheet:
 #  assertTrue $?
-#  assertEquals 1 2
+#  assertEquals ["explanation"] 1 2
 #  oneTimeSetUp()
 #  oneTimeTearDown()
 #  setUp() - run before each test
@@ -136,7 +136,7 @@ test_data_storage_and_retrieval() {
     docker exec "$container_client" sh -c "echo '$data' > /tmp/test_data"
     docker exec "$container_client" memccp --servers="${DOCKER_PREFIX}_server" /tmp/test_data
     retr_data=$(docker exec "$container_client" memccat --servers="${DOCKER_PREFIX}_server" test_data)
-    assertEquals "$data" "$retr_data"
+    assertEquals "Store/retrieve data" "$data" "$retr_data"
 }
 
 load_shunit2

--- a/oci-unit-tests/mysql_test.sh
+++ b/oci-unit-tests/mysql_test.sh
@@ -77,7 +77,7 @@ docker_run_cli() {
 
 wait_mysql_container_ready() {
     local container="${1}"
-    local log="\[System\] \[MY-[0-9]+\] \[Server\] /usr/sbin/mysqld: ready for connections\."
+    local log="\[System\] \[MY-[0-9]+\] \[Server\] /usr/sbin/mysqld: ready for connections\..*port: 3306"
     # mysqld takes a long time to start.
     local timeout=300
 

--- a/oci-unit-tests/mysql_test.sh
+++ b/oci-unit-tests/mysql_test.sh
@@ -52,7 +52,7 @@ docker_run_server() {
 
 # Helper function to invoke the mysql client.
 #
-# The first argument (optiona) is always considered to be the user
+# The first argument (optional) is always considered to be the user
 # that will connect to the server.
 #
 # The rest of the arguments are passed directly to "mysql".
@@ -104,9 +104,10 @@ CREATE DATABASE ${test_db};
 EOF
     # list DB
     debug "Verifying DB ${test_db} was created"
-    out=$(cat <<EOF | docker_run_cli | grep "^${test_db}")
+    out=$(cat <<EOF | docker_run_cli | grep "^${test_db}"
 SHOW DATABASES;
 EOF
+	  )
     assertEquals "DB listing did not include \"mysql\"" "${test_db}" "${out}" || return 1
 }
 
@@ -125,9 +126,10 @@ test_create_user_and_database() {
 
     # list DB
     debug "Verifying DB ${test_db} was created"
-    out=$(cat <<EOF | docker_run_cli ${admin_user} | grep "^${test_db}")
+    out=$(cat <<EOF | docker_run_cli ${admin_user} | grep "^${test_db}"
 SHOW DATABASES;
 EOF
+	  )
     assertEquals "DB listing did not include \"mysql\"" "${test_db}" "${out}" || return 1
 }
 
@@ -168,9 +170,10 @@ test_persistent_volume_keeps_changes() {
     cat <<EOF | docker_run_cli
 CREATE DATABASE ${test_db};
 EOF
-    out=$(cat <<EOF | docker_run_cli | grep "^${test_db}")
+    out=$(cat <<EOF | docker_run_cli | grep "^${test_db}"
 SHOW DATABASES;
 EOF
+	  )
     assertEquals "Failed to create test database" "${test_db}" "${out}" || return 1
 
     # create test table

--- a/oci-unit-tests/mysql_test.sh
+++ b/oci-unit-tests/mysql_test.sh
@@ -1,8 +1,8 @@
 . $(dirname $0)/helper/test_helper.sh
 
 # cheat sheet:
-#  assertTrue() $?
-#  assertEquals() "explanation" 1 2
+#  assertTrue $?
+#  assertEquals ["explanation"] 1 2
 #  oneTimeSetUp()
 #  oneTimeTearDown()
 #  setUp() - run before each test

--- a/oci-unit-tests/mysql_test.sh
+++ b/oci-unit-tests/mysql_test.sh
@@ -1,8 +1,8 @@
 . $(dirname $0)/helper/test_helper.sh
 
 # cheat sheet:
-#  assertTrue $?
-#  assertEquals 1 2
+#  assertTrue() $?
+#  assertEquals() "explanation" 1 2
 #  oneTimeSetUp()
 #  oneTimeTearDown()
 #  setUp() - run before each test
@@ -95,7 +95,7 @@ test_list_and_create_databases() {
 SHOW DATABASES;
 EOF
 	  )
-    assertEquals "DB listing did not include \"mysql\"" mysql "${out}" || return 1
+    assertEquals "DB listing did not include \"mysql\"" "mysql" "${out}" || return 1
     # Verify we can create a new DB, since we are root
     test_db="test_db${id}"
     debug "Trying to create a new DB called ${test_db} as user root"
@@ -108,7 +108,7 @@ EOF
 SHOW DATABASES;
 EOF
 	  )
-    assertEquals "DB listing did not include \"mysql\"" "${test_db}" "${out}" || return 1
+    assertEquals "DB listing did not include \"${test_db}\"" "${test_db}" "${out}" || return 1
 }
 
 test_create_user_and_database() {
@@ -130,7 +130,7 @@ test_create_user_and_database() {
 SHOW DATABASES;
 EOF
 	  )
-    assertEquals "DB listing did not include \"mysql\"" "${test_db}" "${out}" || return 1
+    assertEquals "DB listing did not include \"${test_db}\"" "${test_db}" "${out}" || return 1
 }
 
 test_default_database_name() {

--- a/oci-unit-tests/nginx_test.sh
+++ b/oci-unit-tests/nginx_test.sh
@@ -5,7 +5,7 @@
 
 # cheat sheet:
 #  assertTrue $?
-#  assertEquals 1 2
+#  assertEquals ["explanation"] 1 2
 #  oneTimeSetUp()
 #  oneTimeTearDown()
 #  setUp() - run before each test
@@ -89,7 +89,7 @@ test_static_files() {
     orig_checksum=$(md5sum "$test_data_wwwroot/test.txt" | awk '{ print $1 }')
     retrieved_checksum=$(curl -sS http://127.0.0.1:48080/test.txt | md5sum | awk '{ print $1 }')
 
-    assertEquals "${orig_checksum}" "${retrieved_checksum}"
+    assertEquals "Checksum mismatch from retrieved test.txt" "${orig_checksum}" "${retrieved_checksum}"
 }
 
 test_static_files_read_only_mode() {
@@ -104,7 +104,7 @@ test_static_files_read_only_mode() {
     orig_checksum=$(md5sum "$test_data_wwwroot/test.txt" | awk '{ print $1 }')
     retrieved_checksum=$(curl -sS http://127.0.0.1:48080/test.txt | md5sum | awk '{ print $1 }')
 
-    assertEquals "${orig_checksum}" "${retrieved_checksum}"
+    assertEquals "Checksum mismatch from retrieved test.txt" "${orig_checksum}" "${retrieved_checksum}"
 
     rm -rf "$nginx_scratch"
 }
@@ -121,7 +121,7 @@ test_custom_config() {
     orig_checksum=$(md5sum "$test_data_wwwroot/index.html" | awk '{ print $1 }')
     retrieved_checksum=$(curl -sS http://127.0.0.1:48080/ | md5sum | awk '{ print $1 }')
 
-    assertEquals "${orig_checksum}" "${retrieved_checksum}"
+    assertEquals "Checksum mismatch from retrieved index.html" "${orig_checksum}" "${retrieved_checksum}"
 }
 
 test_reverse_proxy() {
@@ -140,7 +140,7 @@ test_reverse_proxy() {
     assertNotNull "Failed to start the container" "${rp_container}" || return 1
     wait_nginx_container_ready "${rp_container}" || return 1
     retrieved_checksum=$(curl -sS http://127.0.0.1:48070/test.txt | md5sum | awk '{ print $1 }')
-    assertEquals "${orig_checksum}" "${retrieved_checksum}"
+    assertEquals "Checksum mismatch from retrieved test.txt" "${orig_checksum}" "${retrieved_checksum}"
 }
 
 

--- a/oci-unit-tests/postgresql_test.sh
+++ b/oci-unit-tests/postgresql_test.sh
@@ -2,7 +2,7 @@
 
 # cheat sheet:
 #  assertTrue $?
-#  assertEquals 1 2
+#  assertEquals ["explanation"] 1 2
 #  oneTimeSetUp()
 #  oneTimeTearDown()
 #  setUp() - run before each test

--- a/oci-unit-tests/prometheus_test.sh
+++ b/oci-unit-tests/prometheus_test.sh
@@ -5,7 +5,7 @@
 
 # cheat sheet:
 #  assertTrue $?
-#  assertEquals 1 2
+#  assertEquals ["explanation"] 1 2
 #  oneTimeSetUp()
 #  oneTimeTearDown()
 #  setUp() - run before each test

--- a/oci-unit-tests/redis_test.sh
+++ b/oci-unit-tests/redis_test.sh
@@ -2,7 +2,7 @@
 
 # cheat sheet:
 #  assertTrue $?
-#  assertEquals 1 2
+#  assertEquals ["explanation"] 1 2
 #  oneTimeSetUp()
 #  oneTimeTearDown()
 #  setUp() - run before each test

--- a/oci-unit-tests/telegraf_test.sh
+++ b/oci-unit-tests/telegraf_test.sh
@@ -5,7 +5,7 @@
 
 # cheat sheet:
 #  assertTrue $?
-#  assertEquals 1 2
+#  assertEquals ["explanation"] 1 2
 #  oneTimeSetUp()
 #  oneTimeTearDown()
 #  setUp() - run before each test


### PR DESCRIPTION
The mysql_test.sh script didn't work due to some syntax errors in HERE-docs; these are repaired and the operations refactored to simplify them by introducing a docker_mysql_execute() routine that takes a SQL string.  I opted to pass override parameters like MYSQL_USER via local env variables, as I found them reasonably convenient and self-documenting; there's other ways to handle this so if you don't like it we can use a different approach.

(I notice the postgresql test could use a similar refactoring, but left that as is to keep this PR more focused on the mysql test.)

The test was also failing due to starting before the mysql database service was fully ready; thank you for diagnosing that to needing to watch for the port number.  This includes that fix.

Some of the messages used with assertEquals() were incorrect, and in fixing that I noticed some tests weren't providing the explanations, and the "cheat sheet" was documenting the two-argument form, whereas the three-argument form was more common.  This is all now more consistent.