### PR TITLE
OCI: Use the "ubuntu/" namespace to test the images

### DIFF
--- a/oci-unit-tests/alertmanager_test.sh
+++ b/oci-unit-tests/alertmanager_test.sh
@@ -14,7 +14,7 @@
 # The name of the temporary docker network we will create for the
 # tests.
 readonly DOCKER_PREFIX=oci_alertmanager_test
-readonly DOCKER_IMAGE="${DOCKER_IMAGE:-squeakywheel/prometheus-alertmanager:edge}"
+readonly DOCKER_IMAGE="${DOCKER_IMAGE:-ubuntu/prometheus-alertmanager:edge}"
 readonly ALERTMANAGER_PORT=60001
 
 oneTimeSetUp() {

--- a/oci-unit-tests/apache2_test.sh
+++ b/oci-unit-tests/apache2_test.sh
@@ -14,7 +14,7 @@
 # The name of the temporary docker network we will create for the
 # tests.
 readonly DOCKER_PREFIX=oci_apache2_test
-readonly DOCKER_IMAGE="${DOCKER_IMAGE:-squeakywheel/apache2:edge}"
+readonly DOCKER_IMAGE="${DOCKER_IMAGE:-ubuntu/apache2:edge}"
 readonly LOCAL_PORT=59080
 
 oneTimeSetUp() {

--- a/oci-unit-tests/cortex_test.sh
+++ b/oci-unit-tests/cortex_test.sh
@@ -14,7 +14,7 @@
 # The name of the temporary docker network we will create for the
 # tests.
 readonly DOCKER_PREFIX=oci_cortex_test
-readonly DOCKER_IMAGE="${DOCKER_IMAGE:-squeakywheel/cortex:edge}"
+readonly DOCKER_IMAGE="${DOCKER_IMAGE:-ubuntu/cortex:edge}"
 readonly CORTEX_PORT=60009
 
 oneTimeSetUp() {

--- a/oci-unit-tests/grafana_test.sh
+++ b/oci-unit-tests/grafana_test.sh
@@ -14,7 +14,7 @@
 # The name of the temporary docker network we will create for the
 # tests.
 readonly DOCKER_PREFIX=oci_grafana_test
-readonly DOCKER_IMAGE="${DOCKER_IMAGE:-squeakywheel/grafana:edge}"
+readonly DOCKER_IMAGE="${DOCKER_IMAGE:-ubuntu/grafana:edge}"
 readonly LOCAL_PORT=63180
 
 oneTimeSetUp() {

--- a/oci-unit-tests/memcached_test.sh
+++ b/oci-unit-tests/memcached_test.sh
@@ -15,7 +15,7 @@
 # tests.
 readonly DOCKER_PREFIX=oci_memcached_test
 readonly DOCKER_NETWORK="${DOCKER_PREFIX}_network"
-readonly DOCKER_IMAGE="${DOCKER_IMAGE:-squeakywheel/memcached:edge}"
+readonly DOCKER_IMAGE="${DOCKER_IMAGE:-ubuntu/memcached:edge}"
 
 oneTimeSetUp() {
     # Make sure we're using the latest OCI image.

--- a/oci-unit-tests/mysql_test.sh
+++ b/oci-unit-tests/mysql_test.sh
@@ -11,7 +11,7 @@
 # The name of the temporary docker network we will create for the
 # tests.
 readonly DOCKER_NETWORK=mysql_test
-readonly DOCKER_IMAGE="${DOCKER_IMAGE:-squeakywheel/mysql:edge}"
+readonly DOCKER_IMAGE="${DOCKER_IMAGE:-ubuntu/mysql:edge}"
 
 oneTimeSetUp() {
     # Make sure we're using the latest OCI image.

--- a/oci-unit-tests/nginx_test.sh
+++ b/oci-unit-tests/nginx_test.sh
@@ -15,7 +15,7 @@
 # tests.
 readonly DOCKER_PREFIX=oci_nginx_test
 readonly DOCKER_NETWORK="${DOCKER_PREFIX}_network"
-readonly DOCKER_IMAGE="${DOCKER_IMAGE:-squeakywheel/nginx:edge}"
+readonly DOCKER_IMAGE="${DOCKER_IMAGE:-ubuntu/nginx:edge}"
 
 oneTimeSetUp() {
     # Make sure we're using the latest OCI image.

--- a/oci-unit-tests/postgresql_test.sh
+++ b/oci-unit-tests/postgresql_test.sh
@@ -9,7 +9,7 @@
 #  tearDown() - run after each test
 
 readonly DOCKER_NETWORK_NAME="postgresql_test"
-readonly DOCKER_IMAGE="${DOCKER_IMAGE:-squeakywheel/postgresql:edge}"
+readonly DOCKER_IMAGE="${DOCKER_IMAGE:-ubuntu/postgresql:edge}"
 
 oneTimeSetUp() {
     # Make sure we're using the latest OCI image.

--- a/oci-unit-tests/prometheus_test.sh
+++ b/oci-unit-tests/prometheus_test.sh
@@ -15,7 +15,7 @@
 # tests.
 readonly DOCKER_PREFIX=oci_prometheus_test
 readonly DOCKER_NETWORK="${DOCKER_PREFIX}_network"
-readonly DOCKER_IMAGE="${DOCKER_IMAGE:-squeakywheel/prometheus:edge}"
+readonly DOCKER_IMAGE="${DOCKER_IMAGE:-ubuntu/prometheus:edge}"
 readonly DOCKER_PUSHGATEWAY_IMAGE="prom/pushgateway"
 readonly PROM_PORT=50000
 readonly ALERTMANAGER_PORT=50001
@@ -112,7 +112,7 @@ wait_pushgateway_container_ready() {
 test_cli() {
     debug "Check prometheus help via CLI"
     temp_dir=$(mktemp -d)
-    docker run --rm --name "${DOCKER_PREFIX}_${suffix}" squeakywheel/prometheus:edge --help 2>"${temp_dir}/prom_help"
+    docker run --rm --name "${DOCKER_PREFIX}_${suffix}" ubuntu/prometheus:edge --help 2>"${temp_dir}/prom_help"
     out=$(cat "${temp_dir}/prom_help") && ret=1
     if echo "${out}" | grep "The Prometheus monitoring server" >/dev/null; then
         ret=0

--- a/oci-unit-tests/redis_test.sh
+++ b/oci-unit-tests/redis_test.sh
@@ -11,7 +11,7 @@
 # The name of the temporary docker network we will create for the
 # tests.
 readonly DOCKER_NETWORK=redis_test
-readonly DOCKER_IMAGE="${DOCKER_IMAGE:-squeakywheel/redis:edge}"
+readonly DOCKER_IMAGE="${DOCKER_IMAGE:-ubuntu/redis:edge}"
 
 oneTimeSetUp() {
     # Make sure we're using the latest OCI image.

--- a/oci-unit-tests/telegraf_test.sh
+++ b/oci-unit-tests/telegraf_test.sh
@@ -12,7 +12,7 @@
 #  tearDown() - run after each test
 
 readonly DOCKER_PREFIX=oci_telegraf_test
-readonly DOCKER_IMAGE="${DOCKER_IMAGE:-squeakywheel/telegraf:edge}"
+readonly DOCKER_IMAGE="${DOCKER_IMAGE:-ubuntu/telegraf:edge}"
 readonly TELEGRAF_PORT=9273
 
 oneTimeSetUp() {


### PR DESCRIPTION
The test scripts are still using the "squeakywheel/" namespace, which
was just a temporary place to test the images.  This commit updates
the scripts to test the actual released images.