### PR TITLE
oci: parametrize and cleanup the tests

### DIFF
--- a/oci-unit-tests/alertmanager_test.sh
+++ b/oci-unit-tests/alertmanager_test.sh
@@ -14,7 +14,11 @@
 # The name of the temporary docker network we will create for the
 # tests.
 readonly DOCKER_PREFIX=oci_alertmanager_test
-readonly DOCKER_IMAGE="${DOCKER_IMAGE:-ubuntu/prometheus-alertmanager:edge}"
+readonly DOCKER_REGISTRY="${DOCKER_REGISTRY:-docker.io}"
+readonly DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-ubuntu}"
+readonly DOCKER_PACKAGE="${DOCKER_PACKAGE:-prometheus-alertmanager}"
+readonly DOCKER_TAG="${DOCKER_TAG:-edge}"
+readonly DOCKER_IMAGE="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$DOCKER_PACKAGE:$DOCKER_TAG"
 readonly ALERTMANAGER_PORT=60001
 
 oneTimeSetUp() {

--- a/oci-unit-tests/apache2_test.sh
+++ b/oci-unit-tests/apache2_test.sh
@@ -14,7 +14,11 @@
 # The name of the temporary docker network we will create for the
 # tests.
 readonly DOCKER_PREFIX=oci_apache2_test
-readonly DOCKER_IMAGE="${DOCKER_IMAGE:-ubuntu/apache2:edge}"
+readonly DOCKER_REGISTRY="${DOCKER_REGISTRY:-docker.io}"
+readonly DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-ubuntu}"
+readonly DOCKER_PACKAGE="${DOCKER_PACKAGE:-apache2}"
+readonly DOCKER_TAG="${DOCKER_TAG:-edge}"
+readonly DOCKER_IMAGE="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$DOCKER_PACKAGE:$DOCKER_TAG"
 readonly LOCAL_PORT=59080
 
 oneTimeSetUp() {

--- a/oci-unit-tests/apache2_test.sh
+++ b/oci-unit-tests/apache2_test.sh
@@ -2,6 +2,7 @@
 
 # shellcheck disable=SC1090
 . "$(dirname "$0")/helper/test_helper.sh"
+. "$(dirname "$0")/helper/common_vars.sh"
 
 # cheat sheet:
 #  assertTrue $?
@@ -11,14 +12,6 @@
 #  setUp() - run before each test
 #  tearDown() - run after each test
 
-# The name of the temporary docker network we will create for the
-# tests.
-readonly DOCKER_PREFIX=oci_apache2_test
-readonly DOCKER_REGISTRY="${DOCKER_REGISTRY:-docker.io}"
-readonly DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-ubuntu}"
-readonly DOCKER_PACKAGE="${DOCKER_PACKAGE:-apache2}"
-readonly DOCKER_TAG="${DOCKER_TAG:-edge}"
-readonly DOCKER_IMAGE="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$DOCKER_PACKAGE:$DOCKER_TAG"
 readonly LOCAL_PORT=59080
 
 oneTimeSetUp() {

--- a/oci-unit-tests/cortex_test.sh
+++ b/oci-unit-tests/cortex_test.sh
@@ -14,7 +14,11 @@
 # The name of the temporary docker network we will create for the
 # tests.
 readonly DOCKER_PREFIX=oci_cortex_test
-readonly DOCKER_IMAGE="${DOCKER_IMAGE:-ubuntu/cortex:edge}"
+readonly DOCKER_REGISTRY="${DOCKER_REGISTRY:-docker.io}"
+readonly DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-ubuntu}"
+readonly DOCKER_PACKAGE="${DOCKER_PACKAGE:-cortex}"
+readonly DOCKER_TAG="${DOCKER_TAG:-edge}"
+readonly DOCKER_IMAGE="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$DOCKER_PACKAGE:$DOCKER_TAG"
 readonly CORTEX_PORT=60009
 
 oneTimeSetUp() {

--- a/oci-unit-tests/cortex_test.sh
+++ b/oci-unit-tests/cortex_test.sh
@@ -2,6 +2,7 @@
 
 # shellcheck disable=SC1090
 . "$(dirname "$0")/helper/test_helper.sh"
+. "$(dirname "$0")/helper/common_vars.sh"
 
 # cheat sheet:
 #  assertTrue $?
@@ -11,14 +12,6 @@
 #  setUp() - run before each test
 #  tearDown() - run after each test
 
-# The name of the temporary docker network we will create for the
-# tests.
-readonly DOCKER_PREFIX=oci_cortex_test
-readonly DOCKER_REGISTRY="${DOCKER_REGISTRY:-docker.io}"
-readonly DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-ubuntu}"
-readonly DOCKER_PACKAGE="${DOCKER_PACKAGE:-cortex}"
-readonly DOCKER_TAG="${DOCKER_TAG:-edge}"
-readonly DOCKER_IMAGE="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$DOCKER_PACKAGE:$DOCKER_TAG"
 readonly CORTEX_PORT=60009
 
 oneTimeSetUp() {

--- a/oci-unit-tests/grafana_test.sh
+++ b/oci-unit-tests/grafana_test.sh
@@ -14,7 +14,11 @@
 # The name of the temporary docker network we will create for the
 # tests.
 readonly DOCKER_PREFIX=oci_grafana_test
-readonly DOCKER_IMAGE="${DOCKER_IMAGE:-ubuntu/grafana:edge}"
+readonly DOCKER_REGISTRY="${DOCKER_REGISTRY:-docker.io}"
+readonly DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-ubuntu}"
+readonly DOCKER_PACKAGE="${DOCKER_PACKAGE:-grafana}"
+readonly DOCKER_TAG="${DOCKER_TAG:-edge}"
+readonly DOCKER_IMAGE="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$DOCKER_PACKAGE:$DOCKER_TAG"
 readonly LOCAL_PORT=63180
 
 oneTimeSetUp() {

--- a/oci-unit-tests/grafana_test.sh
+++ b/oci-unit-tests/grafana_test.sh
@@ -2,6 +2,7 @@
 
 # shellcheck disable=SC1090
 . "$(dirname "$0")/helper/test_helper.sh"
+. "$(dirname "$0")/helper/common_vars.sh"
 
 # cheat sheet:
 #  assertTrue $?
@@ -11,14 +12,6 @@
 #  setUp() - run before each test
 #  tearDown() - run after each test
 
-# The name of the temporary docker network we will create for the
-# tests.
-readonly DOCKER_PREFIX=oci_grafana_test
-readonly DOCKER_REGISTRY="${DOCKER_REGISTRY:-docker.io}"
-readonly DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-ubuntu}"
-readonly DOCKER_PACKAGE="${DOCKER_PACKAGE:-grafana}"
-readonly DOCKER_TAG="${DOCKER_TAG:-edge}"
-readonly DOCKER_IMAGE="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$DOCKER_PACKAGE:$DOCKER_TAG"
 readonly LOCAL_PORT=63180
 
 oneTimeSetUp() {

--- a/oci-unit-tests/helper/common_vars.sh
+++ b/oci-unit-tests/helper/common_vars.sh
@@ -1,0 +1,11 @@
+# shellcheck shell=dash
+# shellcheck disable=SC2034
+
+readonly DOCKER_REGISTRY="${DOCKER_REGISTRY:-docker.io}"
+readonly DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-ubuntu}"
+readonly DOCKER_PACKAGE="${DOCKER_PACKAGE:-$(basename "$0" | sed 's@\(.*\)_test\.sh@\1@')}"
+readonly DOCKER_TAG="${DOCKER_TAG:-edge}"
+readonly DOCKER_IMAGE="${DOCKER_REGISTRY}/${DOCKER_NAMESPACE}/${DOCKER_PACKAGE}:${DOCKER_TAG}"
+
+readonly DOCKER_PREFIX="${DOCKER_PREFIX:-oci_${DOCKER_PACKAGE}_test}"
+readonly DOCKER_NETWORK="${DOCKER_NETWORK:-${DOCKER_PREFIX}_net}"

--- a/oci-unit-tests/memcached_test.sh
+++ b/oci-unit-tests/memcached_test.sh
@@ -2,6 +2,7 @@
 
 # shellcheck disable=SC1090
 . "$(dirname "$0")/helper/test_helper.sh"
+. "$(dirname "$0")/helper/common_vars.sh"
 
 # cheat sheet:
 #  assertTrue $?
@@ -10,16 +11,6 @@
 #  oneTimeTearDown()
 #  setUp() - run before each test
 #  tearDown() - run after each test
-
-# The name of the temporary docker network we will create for the
-# tests.
-readonly DOCKER_PREFIX=oci_memcached_test
-readonly DOCKER_NETWORK="${DOCKER_PREFIX}_network"
-readonly DOCKER_REGISTRY="${DOCKER_REGISTRY:-docker.io}"
-readonly DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-ubuntu}"
-readonly DOCKER_PACKAGE="${DOCKER_PACKAGE:-memcached}"
-readonly DOCKER_TAG="${DOCKER_TAG:-edge}"
-readonly DOCKER_IMAGE="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$DOCKER_PACKAGE:$DOCKER_TAG"
 
 oneTimeSetUp() {
     # Make sure we're using the latest OCI image.
@@ -30,11 +21,11 @@ oneTimeSetUp() {
     oneTimeTearDown
 
     # Setup network
-    docker network create $DOCKER_NETWORK > /dev/null 2>&1
+    docker network create "$DOCKER_NETWORK" > /dev/null 2>&1
 }
 
 oneTimeTearDown() {
-        docker network rm $DOCKER_NETWORK > /dev/null 2>&1
+        docker network rm "$DOCKER_NETWORK" > /dev/null 2>&1
 }
 
 tearDown() {

--- a/oci-unit-tests/memcached_test.sh
+++ b/oci-unit-tests/memcached_test.sh
@@ -15,7 +15,11 @@
 # tests.
 readonly DOCKER_PREFIX=oci_memcached_test
 readonly DOCKER_NETWORK="${DOCKER_PREFIX}_network"
-readonly DOCKER_IMAGE="${DOCKER_IMAGE:-ubuntu/memcached:edge}"
+readonly DOCKER_REGISTRY="${DOCKER_REGISTRY:-docker.io}"
+readonly DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-ubuntu}"
+readonly DOCKER_PACKAGE="${DOCKER_PACKAGE:-memcached}"
+readonly DOCKER_TAG="${DOCKER_TAG:-edge}"
+readonly DOCKER_IMAGE="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$DOCKER_PACKAGE:$DOCKER_TAG"
 
 oneTimeSetUp() {
     # Make sure we're using the latest OCI image.

--- a/oci-unit-tests/mysql_test.sh
+++ b/oci-unit-tests/mysql_test.sh
@@ -1,3 +1,6 @@
+# shellcheck shell=dash
+
+# shellcheck disable=SC1090
 . $(dirname $0)/helper/test_helper.sh
 
 # cheat sheet:

--- a/oci-unit-tests/mysql_test.sh
+++ b/oci-unit-tests/mysql_test.sh
@@ -1,7 +1,7 @@
 # shellcheck shell=dash
 
 # shellcheck disable=SC1090
-. $(dirname $0)/helper/test_helper.sh
+. "$(dirname "$0")/helper/test_helper.sh"
 
 # cheat sheet:
 #  assertTrue $?
@@ -79,14 +79,14 @@ docker_run_mysql() {
 	   --rm \
 	   -i \
 	   "${DOCKER_IMAGE}" \
-	   mysql -h mysql_test_${id} -u ${user} -p${password} -s "$@" 2>&1 \
+	   mysql -h mysql_test_${id} -u "${user}" -p"${password}" -s "$@" 2>&1 \
 	| grep -vxF "mysql: [Warning] Using a password on the command line interface can be insecure."
 }
 
 # Helper function to send a SQL statement to the mysql client.
 docker_mysql_execute() {
     local sql="${1}"
-    cat <<EOF | docker_run_mysql ${TEST_MYSQL_USER:-root} ${TEST_MYSQL_DB}
+    cat <<EOF | docker_run_mysql "${TEST_MYSQL_USER:-root}" "${TEST_MYSQL_DB}"
 ${sql};
 EOF
 }
@@ -102,7 +102,7 @@ wait_mysql_container_ready() {
 
 test_list_and_create_databases() {
     debug "Creating mysql container (user root)"
-    container=$(docker_run_server -e MYSQL_ROOT_PASSWORD=${password})
+    container=$(docker_run_server -e MYSQL_ROOT_PASSWORD="${password}")
     assertNotNull "Failed to start the container" "${container}" || return 1
     wait_mysql_container_ready "${container}" || return 1
     debug "Testing connection as root, looking for \"mysql\" DB"
@@ -126,9 +126,9 @@ test_create_user_and_database() {
     debug "Creating container with MYSQL_USER=${admin_user} and MYSQL_DATABASE=${test_db}"
     container=$(docker_run_server \
         -e MYSQL_USER=${admin_user} \
-        -e MYSQL_PASSWORD=${password} \
+        -e MYSQL_PASSWORD="${password}" \
 	-e MYSQL_DATABASE=${test_db} \
-	-e MYSQL_ROOT_PASSWORD=${password})
+	-e MYSQL_ROOT_PASSWORD="${password}")
     assertNotNull "Failed to start the container" "${container}" || return 1
     wait_mysql_container_ready "${container}" || return 1
 
@@ -143,7 +143,7 @@ test_default_database_name() {
     debug "Creating container with MYSQL_DATABASE=${test_db}"
     container=$(docker_run_server \
         -e MYSQL_DATABASE=${test_db} \
-        -e MYSQL_ROOT_PASSWORD=${password})
+        -e MYSQL_ROOT_PASSWORD="${password}")
     assertNotNull "Failed to start the container" "${container}" || return 1
     wait_mysql_container_ready "${container}" || return 1
     debug "Checking if database ${test_db} was created"
@@ -159,8 +159,8 @@ test_persistent_volume_keeps_changes() {
     assertNotNull "Failed to create a volume" "${volume}" || return 1
     debug "Launching container"
     container=$(docker_run_server \
-        -e MYSQL_ROOT_PASSWORD=${password} \
-        --mount source=${volume},target=/var/lib/mysql)
+        -e MYSQL_ROOT_PASSWORD="${password}" \
+        --mount source="${volume}",target=/var/lib/mysql)
 
     assertNotNull "Failed to start the container" "${container}" || return 1
     # wait for it to be ready
@@ -186,15 +186,15 @@ test_persistent_volume_keeps_changes() {
     assertEquals "Failed to verify test table" "${id}%hello" "${out}" || return 1
 
     # stop container, which deletes it because it was launched with --rm
-    stop_container_sync ${container}
+    stop_container_sync "${container}"
     # launch another one with the same volume, and the data we created above
     # must still be there
     # By using the same --name also makes sure the previous container is really
     # gone, otherwise the new one wouldn't start
     debug "Launching new container with same volume"
     container=$(docker_run_server \
-        -e MYSQL_ROOT_PASSWORD=${password} \
-        --mount source=${volume},target=/var/lib/mysql)
+        -e MYSQL_ROOT_PASSWORD="${password}" \
+        --mount source="${volume}",target=/var/lib/mysql)
 
     wait_mysql_container_ready "${container}" || return 1
     # data we created previously should still be there

--- a/oci-unit-tests/mysql_test.sh
+++ b/oci-unit-tests/mysql_test.sh
@@ -11,7 +11,11 @@
 # The name of the temporary docker network we will create for the
 # tests.
 readonly DOCKER_NETWORK=mysql_test
-readonly DOCKER_IMAGE="${DOCKER_IMAGE:-ubuntu/mysql:edge}"
+readonly DOCKER_REGISTRY="${DOCKER_REGISTRY:-docker.io}"
+readonly DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-ubuntu}"
+readonly DOCKER_PACKAGE="${DOCKER_PACKAGE:-mysql}"
+readonly DOCKER_TAG="${DOCKER_TAG:-edge}"
+readonly DOCKER_IMAGE="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$DOCKER_PACKAGE:$DOCKER_TAG"
 
 oneTimeSetUp() {
     # Make sure we're using the latest OCI image.

--- a/oci-unit-tests/mysql_test.sh
+++ b/oci-unit-tests/mysql_test.sh
@@ -2,6 +2,7 @@
 
 # shellcheck disable=SC1090
 . "$(dirname "$0")/helper/test_helper.sh"
+. "$(dirname "$0")/helper/common_vars.sh"
 
 # cheat sheet:
 #  assertTrue $?
@@ -11,20 +12,11 @@
 #  setUp() - run before each test
 #  tearDown() - run after each test
 
-# The name of the temporary docker network we will create for the
-# tests.
-readonly DOCKER_NETWORK=mysql_test
-readonly DOCKER_REGISTRY="${DOCKER_REGISTRY:-docker.io}"
-readonly DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-ubuntu}"
-readonly DOCKER_PACKAGE="${DOCKER_PACKAGE:-mysql}"
-readonly DOCKER_TAG="${DOCKER_TAG:-edge}"
-readonly DOCKER_IMAGE="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$DOCKER_PACKAGE:$DOCKER_TAG"
-
 oneTimeSetUp() {
     # Make sure we're using the latest OCI image.
     docker pull --quiet "${DOCKER_IMAGE}" > /dev/null
 
-    docker network create $DOCKER_NETWORK > /dev/null 2>&1
+    docker network create "$DOCKER_NETWORK" > /dev/null 2>&1
 }
 
 setUp() {
@@ -33,7 +25,7 @@ setUp() {
 }
 
 oneTimeTearDown() {
-    docker network rm $DOCKER_NETWORK > /dev/null 2>&1
+    docker network rm "$DOCKER_NETWORK" > /dev/null 2>&1
 }
 
 tearDown() {
@@ -49,7 +41,7 @@ tearDown() {
 # It accepts extra arguments that are then passed to the server.
 docker_run_server() {
     docker run \
-           --network $DOCKER_NETWORK \
+           --network "$DOCKER_NETWORK" \
            --rm \
 	   -d \
 	   --name mysql_test_${id} \
@@ -75,7 +67,7 @@ docker_run_mysql() {
     # warning saying that this is insecure.  That's why we filter out
     # these lines in the end.
     docker run \
-	   --network $DOCKER_NETWORK \
+	   --network "$DOCKER_NETWORK" \
 	   --rm \
 	   -i \
 	   "${DOCKER_IMAGE}" \

--- a/oci-unit-tests/nginx_test.sh
+++ b/oci-unit-tests/nginx_test.sh
@@ -15,7 +15,11 @@
 # tests.
 readonly DOCKER_PREFIX=oci_nginx_test
 readonly DOCKER_NETWORK="${DOCKER_PREFIX}_network"
-readonly DOCKER_IMAGE="${DOCKER_IMAGE:-ubuntu/nginx:edge}"
+readonly DOCKER_REGISTRY="${DOCKER_REGISTRY:-docker.io}"
+readonly DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-ubuntu}"
+readonly DOCKER_PACKAGE="${DOCKER_PACKAGE:-nginx}"
+readonly DOCKER_TAG="${DOCKER_TAG:-edge}"
+readonly DOCKER_IMAGE="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$DOCKER_PACKAGE:$DOCKER_TAG"
 
 oneTimeSetUp() {
     # Make sure we're using the latest OCI image.

--- a/oci-unit-tests/nginx_test.sh
+++ b/oci-unit-tests/nginx_test.sh
@@ -2,6 +2,7 @@
 
 # shellcheck disable=SC1090
 . "$(dirname "$0")/helper/test_helper.sh"
+. "$(dirname "$0")/helper/common_vars.sh"
 
 # cheat sheet:
 #  assertTrue $?
@@ -10,16 +11,6 @@
 #  oneTimeTearDown()
 #  setUp() - run before each test
 #  tearDown() - run after each test
-
-# The name of the temporary docker network we will create for the
-# tests.
-readonly DOCKER_PREFIX=oci_nginx_test
-readonly DOCKER_NETWORK="${DOCKER_PREFIX}_network"
-readonly DOCKER_REGISTRY="${DOCKER_REGISTRY:-docker.io}"
-readonly DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-ubuntu}"
-readonly DOCKER_PACKAGE="${DOCKER_PACKAGE:-nginx}"
-readonly DOCKER_TAG="${DOCKER_TAG:-edge}"
-readonly DOCKER_IMAGE="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$DOCKER_PACKAGE:$DOCKER_TAG"
 
 oneTimeSetUp() {
     # Make sure we're using the latest OCI image.
@@ -30,11 +21,11 @@ oneTimeSetUp() {
     oneTimeTearDown
 
     # Setup network
-    docker network create $DOCKER_NETWORK > /dev/null 2>&1
+    docker network create "$DOCKER_NETWORK" > /dev/null 2>&1
 }
 
 oneTimeTearDown() {
-        docker network rm $DOCKER_NETWORK > /dev/null 2>&1
+        docker network rm "$DOCKER_NETWORK" > /dev/null 2>&1
 }
 
 tearDown() {
@@ -47,7 +38,7 @@ tearDown() {
 docker_run_server() {
     suffix=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 8 | head -n 1)
     docker run \
-       --network $DOCKER_NETWORK \
+       --network "$DOCKER_NETWORK" \
        --rm \
        -d \
        --name "${DOCKER_PREFIX}_${suffix}" \

--- a/oci-unit-tests/postgres_test.sh
+++ b/oci-unit-tests/postgres_test.sh
@@ -1,3 +1,6 @@
+# shellcheck shell=dash
+
+# shellcheck disable=SC1090
 . $(dirname $0)/helper/test_helper.sh
 
 # cheat sheet:

--- a/oci-unit-tests/postgres_test.sh
+++ b/oci-unit-tests/postgres_test.sh
@@ -9,7 +9,11 @@
 #  tearDown() - run after each test
 
 readonly DOCKER_NETWORK_NAME="postgres_test"
-readonly DOCKER_IMAGE="${DOCKER_IMAGE:-ubuntu/postgres:edge}"
+readonly DOCKER_REGISTRY="${DOCKER_REGISTRY:-docker.io}"
+readonly DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-ubuntu}"
+readonly DOCKER_PACKAGE="${DOCKER_PACKAGE:-postgres}"
+readonly DOCKER_TAG="${DOCKER_TAG:-edge}"
+readonly DOCKER_IMAGE="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$DOCKER_PACKAGE:$DOCKER_TAG"
 
 oneTimeSetUp() {
     # Make sure we're using the latest OCI image.

--- a/oci-unit-tests/prometheus-alertmanager_test.sh
+++ b/oci-unit-tests/prometheus-alertmanager_test.sh
@@ -2,6 +2,7 @@
 
 # shellcheck disable=SC1090
 . "$(dirname "$0")/helper/test_helper.sh"
+. "$(dirname "$0")/helper/common_vars.sh"
 
 # cheat sheet:
 #  assertTrue $?
@@ -11,14 +12,6 @@
 #  setUp() - run before each test
 #  tearDown() - run after each test
 
-# The name of the temporary docker network we will create for the
-# tests.
-readonly DOCKER_PREFIX=oci_alertmanager_test
-readonly DOCKER_REGISTRY="${DOCKER_REGISTRY:-docker.io}"
-readonly DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-ubuntu}"
-readonly DOCKER_PACKAGE="${DOCKER_PACKAGE:-prometheus-alertmanager}"
-readonly DOCKER_TAG="${DOCKER_TAG:-edge}"
-readonly DOCKER_IMAGE="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$DOCKER_PACKAGE:$DOCKER_TAG"
 readonly ALERTMANAGER_PORT=60001
 
 oneTimeSetUp() {

--- a/oci-unit-tests/prometheus_test.sh
+++ b/oci-unit-tests/prometheus_test.sh
@@ -15,7 +15,11 @@
 # tests.
 readonly DOCKER_PREFIX=oci_prometheus_test
 readonly DOCKER_NETWORK="${DOCKER_PREFIX}_network"
-readonly DOCKER_IMAGE="${DOCKER_IMAGE:-ubuntu/prometheus:edge}"
+readonly DOCKER_REGISTRY="${DOCKER_REGISTRY:-docker.io}"
+readonly DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-ubuntu}"
+readonly DOCKER_PACKAGE="${DOCKER_PACKAGE:-prometheus}"
+readonly DOCKER_TAG="${DOCKER_TAG:-edge}"
+readonly DOCKER_IMAGE="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$DOCKER_PACKAGE:$DOCKER_TAG"
 readonly DOCKER_PUSHGATEWAY_IMAGE="prom/pushgateway"
 readonly PROM_PORT=50000
 readonly ALERTMANAGER_PORT=50001

--- a/oci-unit-tests/prometheus_test.sh
+++ b/oci-unit-tests/prometheus_test.sh
@@ -2,6 +2,7 @@
 
 # shellcheck disable=SC1090
 . "$(dirname "$0")/helper/test_helper.sh"
+. "$(dirname "$0")/helper/common_vars.sh"
 
 # cheat sheet:
 #  assertTrue $?
@@ -11,15 +12,6 @@
 #  setUp() - run before each test
 #  tearDown() - run after each test
 
-# The name of the temporary docker network we will create for the
-# tests.
-readonly DOCKER_PREFIX=oci_prometheus_test
-readonly DOCKER_NETWORK="${DOCKER_PREFIX}_network"
-readonly DOCKER_REGISTRY="${DOCKER_REGISTRY:-docker.io}"
-readonly DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-ubuntu}"
-readonly DOCKER_PACKAGE="${DOCKER_PACKAGE:-prometheus}"
-readonly DOCKER_TAG="${DOCKER_TAG:-edge}"
-readonly DOCKER_IMAGE="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$DOCKER_PACKAGE:$DOCKER_TAG"
 readonly DOCKER_PUSHGATEWAY_IMAGE="prom/pushgateway"
 readonly PROM_PORT=50000
 readonly ALERTMANAGER_PORT=50001
@@ -39,7 +31,7 @@ oneTimeSetUp() {
     oneTimeTearDown
 
     # Setup network
-    docker network create $DOCKER_NETWORK > /dev/null 2>&1
+    docker network create "$DOCKER_NETWORK" > /dev/null 2>&1
 }
 
 setUp() {
@@ -47,7 +39,7 @@ setUp() {
 }
 
 oneTimeTearDown() {
-    docker network rm $DOCKER_NETWORK > /dev/null 2>&1
+    docker network rm "$DOCKER_NETWORK" > /dev/null 2>&1
 }
 
 tearDown() {
@@ -64,7 +56,7 @@ tearDown() {
 # It accepts extra arguments.
 docker_run_prom() {
     docker run \
-	   --network $DOCKER_NETWORK \
+	   --network "$DOCKER_NETWORK" \
 	   --rm \
 	   -d \
 	   --publish ${PROM_PORT}:9090 \
@@ -76,7 +68,7 @@ docker_run_prom() {
 # Helper function to execute alertmanager.
 docker_run_alertmanager() {
     docker run \
-	   --network $DOCKER_NETWORK \
+	   --network "$DOCKER_NETWORK" \
 	   --rm \
 	   -d \
 	   --publish ${ALERTMANAGER_PORT}:9093 \
@@ -87,7 +79,7 @@ docker_run_alertmanager() {
 # Helper function to execute pushgateway.
 docker_run_pushgateway() {
     docker run \
-	   --network $DOCKER_NETWORK \
+	   --network "$DOCKER_NETWORK" \
 	   --rm \
 	   -d \
 	   --publish ${PUSHGATEWAY_PORT}:9091 \

--- a/oci-unit-tests/redis_test.sh
+++ b/oci-unit-tests/redis_test.sh
@@ -1,3 +1,6 @@
+# shellcheck shell=dash
+
+# shellcheck disable=SC1090
 . $(dirname $0)/helper/test_helper.sh
 
 # cheat sheet:

--- a/oci-unit-tests/redis_test.sh
+++ b/oci-unit-tests/redis_test.sh
@@ -2,6 +2,7 @@
 
 # shellcheck disable=SC1090
 . "$(dirname "$0")/helper/test_helper.sh"
+. "$(dirname "$0")/helper/common_vars.sh"
 
 # cheat sheet:
 #  assertTrue $?
@@ -11,20 +12,11 @@
 #  setUp() - run before each test
 #  tearDown() - run after each test
 
-# The name of the temporary docker network we will create for the
-# tests.
-readonly DOCKER_NETWORK=redis_test
-readonly DOCKER_REGISTRY="${DOCKER_REGISTRY:-docker.io}"
-readonly DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-ubuntu}"
-readonly DOCKER_PACKAGE="${DOCKER_PACKAGE:-redis}"
-readonly DOCKER_TAG="${DOCKER_TAG:-edge}"
-readonly DOCKER_IMAGE="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$DOCKER_PACKAGE:$DOCKER_TAG"
-
 oneTimeSetUp() {
     # Make sure we're using the latest OCI image.
     docker pull --quiet "${DOCKER_IMAGE}" > /dev/null
 
-    docker network create $DOCKER_NETWORK > /dev/null 2>&1
+    docker network create "$DOCKER_NETWORK" > /dev/null 2>&1
 }
 
 setUp() {
@@ -33,7 +25,7 @@ setUp() {
 }
 
 oneTimeTearDown() {
-    docker network rm $DOCKER_NETWORK > /dev/null 2>&1
+    docker network rm "$DOCKER_NETWORK" > /dev/null 2>&1
 }
 
 tearDown() {
@@ -49,7 +41,7 @@ tearDown() {
 # It accepts extra arguments that are then passed to redis-server.
 docker_run_server() {
     docker run \
-	   --network $DOCKER_NETWORK \
+	   --network "$DOCKER_NETWORK" \
 	   --rm \
 	   -d \
 	   --name redis_test_${id} \
@@ -63,7 +55,7 @@ docker_run_server() {
 # to redis-cli.
 docker_run_cli() {
     docker run \
-	   --network $DOCKER_NETWORK \
+	   --network "$DOCKER_NETWORK" \
 	   --rm \
 	   -i \
 	   "${DOCKER_IMAGE}" \

--- a/oci-unit-tests/redis_test.sh
+++ b/oci-unit-tests/redis_test.sh
@@ -11,7 +11,11 @@
 # The name of the temporary docker network we will create for the
 # tests.
 readonly DOCKER_NETWORK=redis_test
-readonly DOCKER_IMAGE="${DOCKER_IMAGE:-ubuntu/redis:edge}"
+readonly DOCKER_REGISTRY="${DOCKER_REGISTRY:-docker.io}"
+readonly DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-ubuntu}"
+readonly DOCKER_PACKAGE="${DOCKER_PACKAGE:-redis}"
+readonly DOCKER_TAG="${DOCKER_TAG:-edge}"
+readonly DOCKER_IMAGE="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$DOCKER_PACKAGE:$DOCKER_TAG"
 
 oneTimeSetUp() {
     # Make sure we're using the latest OCI image.

--- a/oci-unit-tests/redis_test.sh
+++ b/oci-unit-tests/redis_test.sh
@@ -1,7 +1,7 @@
 # shellcheck shell=dash
 
 # shellcheck disable=SC1090
-. $(dirname $0)/helper/test_helper.sh
+. "$(dirname "$0")/helper/test_helper.sh"
 
 # cheat sheet:
 #  assertTrue $?
@@ -152,7 +152,7 @@ test_persistent_volume_keeps_changes() {
     debug "Launching container (with volume)"
     container=$(docker_run_server \
 		    -e REDIS_PASSWORD="${password}" \
-		    --mount source=${volume},target=/var/lib/redis)
+		    --mount source="${volume}",target=/var/lib/redis)
     assertNotNull "Failed to start the container (with volume)" "${container}" || return 1
     # wait for it to be ready
     wait_redis_container_ready "${container}" || return 1
@@ -178,7 +178,7 @@ EOF
 
     # stop container, which deletes it because it was launched with --rm
     debug "Stopping (i.e., deleting) the container (with volume)"
-    stop_container_sync ${container}
+    stop_container_sync "${container}"
     # launch another one with the same volume, and the data we created above
     # must still be there
     # By using the same --name also makes sure the previous container is really
@@ -186,7 +186,7 @@ EOF
     debug "Launching second container (with volume)"
     container=$(docker_run_server \
 		    -e REDIS_PASSWORD="${password}" \
-		    --mount source=${volume},target=/var/lib/redis)
+		    --mount source="${volume}",target=/var/lib/redis)
     assertNotNull "Failed to start the second container (with volume)" "${container}" || return 1
     # wait for it to be ready
     wait_redis_container_ready "${container}" || return 1

--- a/oci-unit-tests/telegraf_test.sh
+++ b/oci-unit-tests/telegraf_test.sh
@@ -12,7 +12,11 @@
 #  tearDown() - run after each test
 
 readonly DOCKER_PREFIX=oci_telegraf_test
-readonly DOCKER_IMAGE="${DOCKER_IMAGE:-ubuntu/telegraf:edge}"
+readonly DOCKER_REGISTRY="${DOCKER_REGISTRY:-docker.io}"
+readonly DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-ubuntu}"
+readonly DOCKER_PACKAGE="${DOCKER_PACKAGE:-telegraf}"
+readonly DOCKER_TAG="${DOCKER_TAG:-edge}"
+readonly DOCKER_IMAGE="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$DOCKER_PACKAGE:$DOCKER_TAG"
 readonly TELEGRAF_PORT=9273
 
 oneTimeSetUp() {

--- a/oci-unit-tests/telegraf_test.sh
+++ b/oci-unit-tests/telegraf_test.sh
@@ -2,6 +2,7 @@
 
 # shellcheck disable=SC1090
 . "$(dirname "$0")/helper/test_helper.sh"
+. "$(dirname "$0")/helper/common_vars.sh"
 
 # cheat sheet:
 #  assertTrue $?
@@ -11,12 +12,6 @@
 #  setUp() - run before each test
 #  tearDown() - run after each test
 
-readonly DOCKER_PREFIX=oci_telegraf_test
-readonly DOCKER_REGISTRY="${DOCKER_REGISTRY:-docker.io}"
-readonly DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-ubuntu}"
-readonly DOCKER_PACKAGE="${DOCKER_PACKAGE:-telegraf}"
-readonly DOCKER_TAG="${DOCKER_TAG:-edge}"
-readonly DOCKER_IMAGE="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$DOCKER_PACKAGE:$DOCKER_TAG"
 readonly TELEGRAF_PORT=9273
 
 oneTimeSetUp() {


### PR DESCRIPTION
Changes:
- oci: fully parametrize the OCI image to test
- oci: add missing shellcheck directives
- oci: make all the scripts shellcheck-clean
