### PR TITLE
git-ubuntu: refactor for core20 base

### DIFF
--- a/git-ubuntu/vm_setup
+++ b/git-ubuntu/vm_setup
@@ -7,9 +7,8 @@ set -e
 VERBOSITY=0
 
 rand_name=$(uuidgen -r | cut -c1-8)
-VM_NAME="${1:-xenial-$rand_name}"
-RELEASE="xenial"
-SNAPCRAFT_TYPE="deb"
+VM_NAME="${1:-focal-$rand_name}"
+RELEASE="focal"
 
 error() { echo "$@" 1>&2; }
 fail() { [ $# -eq 0 ] || error "$@"; exit 1; }
@@ -77,7 +76,7 @@ vm_push() {
 
 main() {
     local short_opts="hv"
-    local long_opts="help,verbose,snapcraft-deb,snapcraft-snap"
+    local long_opts="help,verbose"
     local getopt_out=""
     getopt_out=$(getopt --name "${0##*/}" \
         --options "${short_opts}" --long "${long_opts}" -- "$@") ||
@@ -91,8 +90,6 @@ main() {
         case "$cur" in
             -h|--help) usage ; exit 0;;
             -v|--verbose) VERBOSITY=$((VERBOSITY+1));;
-	    --snapcraft-deb) SNAPCRAFT_TYPE=deb;;
-	    --snapcraft-snap) SNAPCRAFT_TYPE=snap;;
             --) shift; break;;
         esac
         shift;
@@ -115,33 +112,9 @@ main() {
 	vm_exec "$VM_NAME" "sudo systemctl restart snapd.service"
     fi
 
-    echo "installing core snap"
-    vm_exec "$VM_NAME" "sudo snap install core"
-
-    if [ "$SNAPCRAFT_TYPE" = "snap" ]; then
-        # LP: 1746612 "Snapcraft cleanbuild doesn't work if you're not using the LXD snap"
-        # Replace lxd deb with snap
-        vm_exec "$VM_NAME" "sudo apt-get -y purge lxd liblxc1 lxc-common lxcfs lxd-client"
-        vm_exec "$VM_NAME" "sudo rm -rf /var/lib/lxd"
-        vm_exec "$VM_NAME" "sudo snap install lxd"
-
-        # Workaround for LP: #1777445
-        vm_exec "$VM_NAME" "sudo ln -s /snap/bin/lxc /usr/local/bin/lxc"
-    fi
-
-    # -t 60 doesn't work in lxd 2.0.11-0ubuntu1~16.04.4; --timeout=60 appears to work everywhere
-    vm_exec "$VM_NAME" "sudo lxd waitready --timeout=60"
-
-    echo "configuring LXD networking"
-    vm_exec "$VM_NAME" "sudo sed -i 's/LXD_IPV4_ADDR=\"\"/LXD_IPV4_ADDR=\"10.158.98.1\"/' /etc/default/lxd-bridge"
-    vm_exec "$VM_NAME" "sudo sed -i 's/LXD_IPV4_NETMASK=\"\"/LXD_IPV4_NETMASK=\"255.255.255.0\"/' /etc/default/lxd-bridge"
-    vm_exec "$VM_NAME" "sudo sed -i 's/LXD_IPV4_NETWORK=\"\"/LXD_IPV4_NETWORK=\"10.158.98.1\/24\"/' /etc/default/lxd-bridge"
-    vm_exec "$VM_NAME" "sudo sed -i 's/LXD_IPV4_DHCP_RANGE=\"\"/LXD_IPV4_DHCP_RANGE=\"10.158.98.2,10.158.98.254\"/' /etc/default/lxd-bridge"
-    vm_exec "$VM_NAME" "sudo sed -i 's/LXD_IPV4_DHCP_MAX=\"\"/LXD_IPV4_DHCP_MAX=\"252\"/' /etc/default/lxd-bridge"
+    echo "configuring LXD"
     vm_exec "$VM_NAME" "sudo lxd init --auto"
-    if [ "$SNAPCRAFT_TYPE" = "deb" ]; then
-        vm_exec "$VM_NAME" "sudo dpkg-reconfigure -fnoninteractive -p medium lxd"
-    fi
+    vm_exec "$VM_NAME" "sudo lxd waitready --timeout=60"
 
     if [ ! -z "${https_proxy-}" ]; then
         echo "configuring lxc profile https_proxy"
@@ -151,25 +124,6 @@ main() {
         echo "configuring lxc profile http_proxy"
         vm_exec "$VM_NAME" "lxc profile set default environment.http_proxy ${http_proxy}"
     fi
-
-    echo "congiuring git user info"
-    vm_exec "$VM_NAME" "git config --global gitubuntu.lpuser usd-importer-bot"
-    vm_exec "$VM_NAME" "git config --global user.email \"test@ubuntu.com\""
-    vm_exec "$VM_NAME" "git config --global user.name \"Test User\""
-    vm_exec "$VM_NAME" "git config --global url.'https://git.launchpad.net/'.insteadOf lp:"
-
-    echo "installing dependnecies"
-    vm_exec "$VM_NAME" "sudo apt-get update"
-
-    if [ "$SNAPCRAFT_TYPE" = "deb" ]; then
-        vm_exec "$VM_NAME" "sudo apt-get install -y snapcraft"
-    elif [ "$SNAPCRAFT_TYPE" = "snap" ]; then
-        vm_exec "$VM_NAME" "sudo snap install --edge --classic snapcraft"
-
-        # Workaround for LP: #1777445
-        vm_exec "$VM_NAME" "sudo ln -s /snap/bin/snapcraft /usr/local/bin/snapcraft"
-    fi
-
 
     return 0
 }


### PR DESCRIPTION
Now that we're building on core20 based on a deb, much of the complexity
here can disappear. The base image is switched to Focal. snapcraft is
now always a snap, and so is lxd. The updated tests rely less on the
environment so git no longer needs configuring first.