### PR TITLE
OCI: Fix apache2 configure loading

### DIFF
--- a/oci-unit-tests/apache2_test.sh
+++ b/oci-unit-tests/apache2_test.sh
@@ -67,7 +67,7 @@ test_default_config_ipv6() {
 
 test_static_content() {
     debug "Creating all-defaults apache2 container"
-    test_data_wwwroot="$PWD/apache2_test_data/html"
+    test_data_wwwroot="$(realpath -e $(dirname "$0"))/apache2_test_data/html"
     container=$(docker_run_server -p "$LOCAL_PORT:80" -v "$test_data_wwwroot:/var/www/html:ro")
 
     assertNotNull "Failed to start the container" "${container}" || return 1
@@ -81,8 +81,8 @@ test_static_content() {
 
 test_custom_config() {
     debug "Creating apache2 container with custom config"
-    custom_config="$PWD/apache2_test_data/apache2_simple.conf"
-    test_data_wwwroot="$PWD/apache2_test_data/html"
+    custom_config="$(realpath -e $(dirname "$0"))/apache2_test_data/apache2_simple.conf"
+    test_data_wwwroot="$(realpath -e $(dirname "$0"))/apache2_test_data/html"
     container=$(docker_run_server -p "$LOCAL_PORT:80" -v "$custom_config:/etc/apache2/apache2.conf:ro" -v "$test_data_wwwroot:/srv/www:ro")
 
     assertNotNull "Failed to start the container" "${container}" || return 1


### PR DESCRIPTION
The apache2 unit test is using $PWD when composing the path for the
configure files to be mounted inside the container.  This doesn't work
when we're running these tests from an external directory.  We should
use the same pattern we're using to source the helper scripts here,
with the addition of calling "realpath", which is necessary because
docker requires that mount paths be fullpaths.