### PR TITLE
WIP: OCI: Test if all supported architectures have been published

### DIFF
--- a/oci-unit-tests/helper/common_vars.sh
+++ b/oci-unit-tests/helper/common_vars.sh
@@ -9,3 +9,6 @@ readonly DOCKER_IMAGE="${DOCKER_IMAGE:-${DOCKER_REGISTRY}/${DOCKER_NAMESPACE}/${
 
 readonly DOCKER_PREFIX="${DOCKER_PREFIX:-oci_${DOCKER_PACKAGE}_test}"
 readonly DOCKER_NETWORK="${DOCKER_NETWORK:-${DOCKER_PREFIX}_net}"
+
+# List of all supported architectures for the images.
+readonly SUPPORTED_ARCHITECTURES="amd64 arm64 ppc64el s390x"

--- a/oci-unit-tests/standalone-checks_test.sh
+++ b/oci-unit-tests/standalone-checks_test.sh
@@ -1,0 +1,101 @@
+# shellcheck shell=dash
+
+# shellcheck disable=SC1090
+. "$(dirname "$0")/helper/test_helper.sh"
+. "$(dirname "$0")/helper/common_vars.sh"
+
+# cheat sheet:
+#  assertTrue $?
+#  assertEquals ["explanation"] 1 2
+#  oneTimeSetUp()
+#  oneTimeTearDown()
+#  setUp() - run before each test
+#  tearDown() - run after each test
+
+# Standalone checks that will be performed for each image.
+
+# Check that all supported architectures are present in the manifest
+# list for every image.
+test_all_supported_architectures_are_available()
+{
+    # We only support querying AWS for now.
+    local registries="aws"
+    local namespaces="ubuntu lts"
+    local utilsdir
+    local listed_architectures
+    local images_list
+    # Which tags to test.
+    local tags_regex='\(latest\|beta\|edge\)'
+    local ret=0
+
+    utilsdir="$(mktemp -d)/utils"
+    trap 'rm -rf ${utilsdir}' 0 INT QUIT ABRT PIPE TERM
+
+    debug "Checking if all supported architectures are present in the manifest list of each image"
+
+    if ! git clone -q --depth 1 https://git.launchpad.net/~canonical-server/ubuntu-docker-images/+git/utils "${utilsdir}"; then
+	debug "failed to clone 'utils' repository"
+	exit 1
+    fi
+
+    # Iterate over the available registries...
+    for registry in ${registries}; do
+        # ... and over the available namespaces...
+        for namespace in ${namespaces}; do
+            # ... and over the list of all images for the
+            # registry/namespace combination...
+            images_list=$("${utilsdir}"/list-all-images.sh \
+                                       --registry "${registry}" \
+                                       --namespace "${namespace}")
+            if [ "${DOCKER_PACKAGE}" != "$(basename "$0" | sed 's@\(.*\)_test\.sh@\1@')" ]; then
+                # If the user has specified an image name to be tested, then
+                # we just test it.
+                if ! images_list=$(echo "${images_list}" | grep -Fw "${DOCKER_PACKAGE}"); then
+                    continue
+                fi
+            fi
+            for image in ${images_list}; do
+                # ... and over the list of all available tags for each
+                # image...
+                for tag in $("${utilsdir}"/list-tags-for-image.sh \
+                                          --registry "${registry}" \
+                                          --namespace "${namespace}" \
+                                          --image "${image}" \
+                                 | grep "${tags_regex}"); do
+                    debug "Checking manifest list for ${namespace}/${image}:${tag} on ${registry}"
+                    # Obtain the manifest list for the current tag,
+                    # and filter out everything but the published
+                    # architectures.
+                    listed_architectures=$("${utilsdir}"/list-manifest-for-image-and-tag.sh \
+					                --registry "${registry}" \
+					                --namespace "${namespace}" \
+					                --image "${image}" \
+					                --tag "${tag}" \
+			                       | jq -r '.manifests[].platform.architecture')
+                    if [ -z "${listed_architectures}" ]; then
+                        # Check if we've gotten a valid output from
+                        # the commands above.  Albeit rare, it is
+                        # possible that the manifest list comes out empty.
+                        echo "E: Could not obtain manifest list for ${namespace}/${image}:${tag} on ${registry}" > /dev/stderr
+                        ret=1
+                        continue
+                    fi
+                    for arch in ${SUPPORTED_ARCHITECTURES}; do
+	                if ! echo "${listed_architectures}" | grep -Fwq "${arch}"; then
+	                    echo "E: architecture '${arch}' not found in the manifest list of ${namespace}/${image}:${tag} on ${registry}" > /dev/stderr
+	                    ret=1
+	                else
+                            debug "architecture '${arch}' successfully found in the manifest list of ${namespace}/${image}:${tag} on ${registry}"
+                        fi
+                    done
+                done
+            done
+        done
+    done
+
+    rm -rf "${utilsdir}"
+
+    assertTrue "Not all supported architectures are available" "$ret"
+}
+
+load_shunit2


### PR DESCRIPTION
**NOTE: This is currently a WIP**

I've decided to take a stab at implementing the test to verify whether
all supported architectures of an image have been properly published.

I don't know if this is the best way to implement this; sometimes I
think it is, other times I think it would be better to write this test
in its own file.

The reason I chose to write this as a helper function (which then
means that it will have to be called by every `*_test.sh` script) is
because we are going to have the test matrix which will cover all
registries x all namespaces x all tags anyway, so why don't take
advantage of that?  But again, this could very well be placed in its
own test file; a benefit is that we can then write generic tests for
all images there (for example, another test that I'm writing now is
the one that verifies whether the published hashes on Dockerhub match
those published on AWS).  Ah, and yet another benefit would be that we
wouldn't need the ugly hack I had to do on `common_vars.sh`.  See?  I
told you, I haven't really decided what's best here :-P.

By the way, I know that we've mentioned during standup that we could
just test images from one registry and be done with it (since we will
have the other test in place which will guarantee that the images are
the same on Dockerhub and AWS), but I think it's actually better to
test everything, because the list of supported architectures may
differ between registries for the same image.

Either way, I'd like an opinion about the test itself and the approach
taken from you guys.  This currently only implements the test for
telegraf.  In order to see it running, you have to invoke it like:

```
$ DOCKER_REGISTRY=public.ecr.aws sh telegraf_test.sh
```

Bear in mind that:

* You will have to `docker login` into AWS first.
* The test will fail, because not all architectures are available.