### PR TITLE
OCI: Use "ppc64le" as the arch name

### DIFF
--- a/oci-unit-tests/helper/common_vars.sh
+++ b/oci-unit-tests/helper/common_vars.sh
@@ -11,7 +11,7 @@ readonly DOCKER_PREFIX="${DOCKER_PREFIX:-oci_${DOCKER_PACKAGE}_test}"
 readonly DOCKER_NETWORK="${DOCKER_NETWORK:-${DOCKER_PREFIX}_net}"
 
 # List of all supported architectures for the images.
-readonly SUPPORTED_ARCHITECTURES="amd64 arm64 ppc64el s390x"
+readonly SUPPORTED_ARCHITECTURES="amd64 arm64 ppc64le s390x"
 # List of all supported registries.
 readonly SUPPORTED_REGISTRIES="aws docker"
 # List of all supported namespaces.


### PR DESCRIPTION
Ref.: https://bugs.launchpad.net/bugs/1930094

The official architecture name that Docker uses is "ppc64le", not
"ppc64el".