### PR TITLE
OCI: Remove previous image before starting test

### DIFF
--- a/oci-unit-tests/apache2_test.sh
+++ b/oci-unit-tests/apache2_test.sh
@@ -15,6 +15,9 @@
 readonly LOCAL_PORT=59080
 
 oneTimeSetUp() {
+    # Remove image before test.
+    remove_current_image
+
     # Make sure we're using the latest OCI image.
     docker pull --quiet "${DOCKER_IMAGE}" > /dev/null
 

--- a/oci-unit-tests/cortex_test.sh
+++ b/oci-unit-tests/cortex_test.sh
@@ -15,6 +15,9 @@
 readonly CORTEX_PORT=60009
 
 oneTimeSetUp() {
+    # Remove image before test.
+    remove_current_image
+
     # Make sure we're using the latest OCI image.
     docker pull --quiet "${DOCKER_IMAGE}" > /dev/null
 

--- a/oci-unit-tests/grafana_test.sh
+++ b/oci-unit-tests/grafana_test.sh
@@ -15,6 +15,9 @@
 readonly LOCAL_PORT=63180
 
 oneTimeSetUp() {
+    # Remove image before test.
+    remove_current_image
+
     # Make sure we're using the latest OCI image.
     docker pull --quiet "${DOCKER_IMAGE}" > /dev/null
 

--- a/oci-unit-tests/helper/test_helper.sh
+++ b/oci-unit-tests/helper/test_helper.sh
@@ -97,3 +97,16 @@ check_manifest_exists()
     debug "not found"
     return 1
 }
+
+# Remove the current image.
+# This is useful before starting a test, in order to make sure that
+# we're using the latest image available to us.
+remove_current_image()
+{
+    # Remove the current downloaded image.  Just do it if the image
+    # spec (${DOCKER_IMAGE}) starts with ${DOCKER_REGISTRY}, because
+    # we don't want to remove locally built images.
+    if echo "${DOCKER_IMAGE}" | grep -q "^${DOCKER_REGISTRY}"; then
+        docker image rm --force "${DOCKER_IMAGE}" > /dev/null 2>&1
+    fi
+}

--- a/oci-unit-tests/memcached_test.sh
+++ b/oci-unit-tests/memcached_test.sh
@@ -13,6 +13,9 @@
 #  tearDown() - run after each test
 
 oneTimeSetUp() {
+    # Remove image before test.
+    remove_current_image
+
     # Make sure we're using the latest OCI image.
     docker pull --quiet "${DOCKER_IMAGE}" > /dev/null
 

--- a/oci-unit-tests/mysql_test.sh
+++ b/oci-unit-tests/mysql_test.sh
@@ -13,6 +13,9 @@
 #  tearDown() - run after each test
 
 oneTimeSetUp() {
+    # Remove image before test.
+    remove_current_image
+
     # Make sure we're using the latest OCI image.
     docker pull --quiet "${DOCKER_IMAGE}" > /dev/null
 

--- a/oci-unit-tests/nginx_test.sh
+++ b/oci-unit-tests/nginx_test.sh
@@ -13,6 +13,9 @@
 #  tearDown() - run after each test
 
 oneTimeSetUp() {
+    # Remove image before test.
+    remove_current_image
+
     # Make sure we're using the latest OCI image.
     docker pull --quiet "${DOCKER_IMAGE}" > /dev/null
 

--- a/oci-unit-tests/postgres_test.sh
+++ b/oci-unit-tests/postgres_test.sh
@@ -13,6 +13,9 @@
 #  tearDown() - run after each test
 
 oneTimeSetUp() {
+    # Remove image before test.
+    remove_current_image
+
     # Make sure we're using the latest OCI image.
     docker pull --quiet "${DOCKER_IMAGE}" > /dev/null
 

--- a/oci-unit-tests/prometheus-alertmanager_test.sh
+++ b/oci-unit-tests/prometheus-alertmanager_test.sh
@@ -15,6 +15,9 @@
 readonly ALERTMANAGER_PORT=60001
 
 oneTimeSetUp() {
+    # Remove image before test.
+    remove_current_image
+
     # Make sure we're using the latest OCI image.
     docker pull --quiet "${DOCKER_IMAGE}" > /dev/null
 

--- a/oci-unit-tests/prometheus_test.sh
+++ b/oci-unit-tests/prometheus_test.sh
@@ -23,6 +23,9 @@ if [ -z "${DOCKER_ALERTMANAGER_IMAGE}" ]; then
 fi
 
 oneTimeSetUp() {
+    # Remove image before test.
+    remove_current_image
+
     # Make sure we're using the latest OCI image.
     docker pull --quiet "${DOCKER_IMAGE}" > /dev/null
 

--- a/oci-unit-tests/redis_test.sh
+++ b/oci-unit-tests/redis_test.sh
@@ -13,6 +13,9 @@
 #  tearDown() - run after each test
 
 oneTimeSetUp() {
+    # Remove image before test.
+    remove_current_image
+
     # Make sure we're using the latest OCI image.
     docker pull --quiet "${DOCKER_IMAGE}" > /dev/null
 

--- a/oci-unit-tests/telegraf_test.sh
+++ b/oci-unit-tests/telegraf_test.sh
@@ -15,6 +15,9 @@
 readonly TELEGRAF_PORT=9273
 
 oneTimeSetUp() {
+    # Remove image before test.
+    remove_current_image
+
     # Make sure we're using the latest OCI image.
     docker pull --quiet "${DOCKER_IMAGE}" > /dev/null
 


### PR DESCRIPTION
When running a test whose image cannot be downloaded from the
registry, docker will use the cached image (from a previous run).  In
order to prevent this misleading scenario from happening, this commit
forces the removal of an existing image before we start testing.

Note that we just remove the image if `"${DOCKER_IMAGE}"` (which
contains the full image spec) starts with `"${DOCKER_REGISTRY}"`.  This
is necessary in order to continue supporting testing locally built
images.