### PR TITLE
OCI: Use "classic" interface when querying prometheus' endpoints

### DIFF
--- a/oci-unit-tests/prometheus_test.sh
+++ b/oci-unit-tests/prometheus_test.sh
@@ -131,7 +131,7 @@ test_default_target() {
     sleep 20
 
     debug "Check if the default prometheus target is running"
-    out=$(curl --silent "http://localhost:${PROM_PORT}/targets" \
+    out=$(curl --silent "http://localhost:${PROM_PORT}/classic/targets" \
 	    | grep job-prometheus \
             | cut -d '>' -f 2 \
             | cut -d '<' -f 1)
@@ -158,7 +158,7 @@ EOF
     wait_prometheus_container_ready "${container}" || return 1
 
     debug "Check if the alertmanager is configured"
-    out=$(curl --silent "http://localhost:${PROM_PORT}/status")
+    out=$(curl --silent "http://localhost:${PROM_PORT}/classic/status")
     assertTrue echo "${out}" | grep "${alertmanager_url}" >/dev/null
 }
 
@@ -189,7 +189,7 @@ EOF
     wait_prometheus_container_ready "${container}" || return 1
 
     debug "Check if the alert is active"
-    out=$(curl --silent "http://localhost:${PROM_PORT}/alerts")
+    out=$(curl --silent "http://localhost:${PROM_PORT}/classic/alerts")
     assertTrue echo "${out}" | grep "${alert_name}" | grep active >/dev/null
 }
 


### PR DESCRIPTION
The version of prometheus that's being delivered in our OCI image has
updated their web interface and are now making extensive use of
JavaScript; it actually *requires* JavaScript now, so a simple "curl"
won't be able to obtain useful information from the pages.

Our test was written for a previous version of prometheus, which
worked fine with "curl".  Fortunately, upstream has kept the "classic"
interface around, so it's still possible to query the pages we need
using it.

Of course, there's the question of how long upstream will be willing
to maintain the classic interface.  We might have to revisit this
later, but for now it works.