### PR TITLE
OCI: Don't create a network on nginx_test.sh

### DIFF
--- a/oci-unit-tests/nginx_test.sh
+++ b/oci-unit-tests/nginx_test.sh
@@ -21,14 +21,6 @@ oneTimeSetUp() {
 
     # Cleanup stale resources
     tearDown
-    oneTimeTearDown
-
-    # Setup network
-    docker network create "$DOCKER_NETWORK" > /dev/null 2>&1
-}
-
-oneTimeTearDown() {
-        docker network rm "$DOCKER_NETWORK" > /dev/null 2>&1
 }
 
 tearDown() {
@@ -41,7 +33,6 @@ tearDown() {
 docker_run_server() {
     suffix=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 8 | head -n 1)
     docker run \
-       --network "$DOCKER_NETWORK" \
        --rm \
        -d \
        --name "${DOCKER_PREFIX}_${suffix}" \


### PR DESCRIPTION
Docker's IPv6 network support isn't very trivial to set up.

It's possible to enable IPv6 on the bridge that is used by all images
by default, and that works OOTB; however, having IPv6 support on
"docker network create" is a bit more involved and requires us to
provide a "--subnet" argument to the command.

Instead of messing with arguments, I suggest that the nginx unit test
doesn't create its own network, and instead rely on the host network,
like the apache2 unit test does (this was Athos' original suggestion
from the beginning, btw).

I think it'd be great to have every test running on its own isolated
network, but until we have a better way to fire them up with IPv6
support I don't see an easy way to overcome this problem.