### PR TITLE
OCI: Adjust message when number of images differ between registries

### DIFF
--- a/oci-unit-tests/standalone-checks_test.sh
+++ b/oci-unit-tests/standalone-checks_test.sh
@@ -181,17 +181,13 @@ test_images_hashes_are_equal()
                 cnt_images_list_tmp=$(echo "${images_list_tmp}" | wc -w)
 
                 if [ "${cnt_images_list}" -lt "${cnt_images_list_tmp}" ]; then
-                    echo "E: Registry '${registry}' contains more images than '${orig_registry}'.  Here are the extra images:" > /dev/stderr
+                    echo "W: Registry '${registry}' contains more images than '${orig_registry}'.  Here are the extra images:" > /dev/stderr
                     echo > /dev/stderr
                     echo "$(echo "${images_list_tmp}" | grep -Fvw "${images_list}")"
-                    echo > /dev/stderr
-                    echo "E: Aborting." > /dev/stderr
                 elif [ "${cnt_images_list}" -gt "${cnt_images_list_tmp}" ]; then
-                    echo "E: Registry '${registry}' contains less images than '${orig_registry}'.  Here are the missing images:" > /dev/stderr
+                    echo "W: Registry '${registry}' contains less images than '${orig_registry}'.  Here are the missing images:" > /dev/stderr
                     echo > /dev/stderr
                     echo "$(echo "${images_list}" | grep -Fvw "${images_list_tmp}")"
-                    echo > /dev/stderr
-                    echo "E: Aborting." > /dev/stderr
                 fi
             fi
         done


### PR DESCRIPTION
Currently we print a message tagged as "error" when there is a
mismatch between the number of images available in one registry and
another.  We also print a misguided message saying that the test will
be aborted, when in fact it is not.

This message can be just a warning, since it doesn't actually impact
the actual test.