### PR TITLE
HA: iscsi setup

### DIFF
--- a/ha/virsh/delete-cluster.sh
+++ b/ha/virsh/delete-cluster.sh
@@ -2,9 +2,17 @@
 
 : "${UBUNTU_SERIES:=impish}"
 VM_PREFIX="fence-test-virsh-${UBUNTU_SERIES}-node"
+VM_SERVICES="services-${UBUNTU_SERIES}"
 
+# Remove all cluster nodes
 virsh list --state-running --name | grep "^$VM_PREFIX" | xargs -L 1 --no-run-if-empty virsh destroy
 virsh list --state-shutoff --name | grep "^$VM_PREFIX" | xargs -L 1 --no-run-if-empty virsh undefine --remove-all-storage
+
+# Remove VM running external services if it exists
+if virsh list --name | grep ${VM_SERVICES}; then
+  virsh destroy ${VM_SERVICES}
+  virsh undefine --remove-all-storage ${VM_SERVICES}
+fi
 
 # Check for leftover VMs (cleanup failed!)
 ! virsh list --all --name | grep -q "^$VM_PREFIX" || exit 1

--- a/ha/virsh/setup-cluster.sh
+++ b/ha/virsh/setup-cluster.sh
@@ -126,10 +126,10 @@ copy_config_files_to_all_nodes() {
   copy_to_all_nodes "${CONFIG_DIR}"/corosync.conf
 }
 
-block_until_cloud_init_is_done() {
-  # set debconf frontend to Noninteractive
-  run_in_all_nodes "echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections"
-  run_in_all_nodes "cloud-init status --wait"
+wait_until_all_nodes_are_ready() {
+  block_until_cloud_init_is_done "${IP_VM01}"
+  block_until_cloud_init_is_done "${IP_VM02}"
+  block_until_cloud_init_is_done "${IP_VM03}"
 }
 
 setup_config_files_in_all_nodes() {
@@ -160,6 +160,6 @@ generate_ssh_key_in_the_host
 verify_all_nodes_reachable_via_ssh
 copy_ssh_key_to_all_nodes
 copy_config_files_to_all_nodes
-block_until_cloud_init_is_done
+wait_until_all_nodes_are_ready
 setup_config_files_in_all_nodes
 check_if_all_nodes_are_online

--- a/ha/virsh/setup-cluster.sh
+++ b/ha/virsh/setup-cluster.sh
@@ -5,13 +5,61 @@ set -eux -o pipefail
 # shellcheck disable=SC1090
 . "$(dirname "$0")/vm_utils.sh"
 
-WORK_DIR="${1:-$(pwd)}"
-CONFIG_DIR="${2:-"${WORK_DIR}/config"}"
+WORK_DIR="$(pwd)"
+CONFIG_DIR="${WORK_DIR}/config"
+ISCSI=NO
 
 CREATE_VM_SCRIPT="$(pwd)/create-vm.sh"
 
+while [[ $# -gt 0 ]]; do
+  option="$1"
+  case $option in
+    --workdir)
+      WORK_DIR="$2"
+      shift
+      shift
+      ;;
+    --configdir)
+      CONFIG_DIR="$2"
+      shift
+      shift
+      ;;
+    --iscsi)
+      ISCSI=YES
+      shift
+      ;;
+    *)
+      # Do nothing
+      ;;
+  esac
+done
+
 check_requirements() {
     hash virsh ssh-keygen wget virt-install qemu-img cloud-localds uuidgen || exit 127
+}
+
+create_service_vm() {
+  ${CREATE_VM_SCRIPT} "${VM_SERVICES}" "$(pwd)"
+  sleep 20
+  get_vm_services_ip_address
+  block_until_cloud_init_is_done "${IP_VM_SERVICES}"
+}
+
+setup_iscsi_target() {
+  run_command_in_node "${IP_VM_SERVICES}" "sudo apt-get update && sudo apt-get install -y targetcli-fb"
+  run_command_in_node "${IP_VM_SERVICES}" "sudo targetcli backstores/block create name=iscsi-disk01 dev=/dev/vdc"
+  run_command_in_node "${IP_VM_SERVICES}" "sudo targetcli iscsi/ create ${IQN}:${VM_SERVICES_ISCSI_TARGET}"
+  run_command_in_node "${IP_VM_SERVICES}" "sudo targetcli iscsi/${IQN}:${VM_SERVICES_ISCSI_TARGET}/tpg1/luns create /backstores/block/iscsi-disk01"
+  run_command_in_node "${IP_VM_SERVICES}" "sudo targetcli iscsi/${IQN}:${VM_SERVICES_ISCSI_TARGET}/tpg1/acls create ${IQN}:${VM01_ISCSI_INITIATOR}"
+  run_command_in_node "${IP_VM_SERVICES}" "sudo targetcli iscsi/${IQN}:${VM_SERVICES_ISCSI_TARGET}/tpg1/acls create ${IQN}:${VM02_ISCSI_INITIATOR}"
+  run_command_in_node "${IP_VM_SERVICES}" "sudo targetcli iscsi/${IQN}:${VM_SERVICES_ISCSI_TARGET}/tpg1/acls create ${IQN}:${VM03_ISCSI_INITIATOR}"
+}
+
+setup_service_vm() {
+  if [[ "$ISCSI" == "YES" ]]; then
+    create_service_vm
+    setup_iscsi_target
+  fi
 }
 
 create_nodes() {
@@ -92,9 +140,19 @@ logging {
 EOF
 }
 
+write_iscsi_initiator_conf_files() {
+  echo "InitiatorName=${IQN}:${VM01_ISCSI_INITIATOR}" > "${CONFIG_DIR}"/vm01_initiatorname.iscsi
+  echo "InitiatorName=${IQN}:${VM02_ISCSI_INITIATOR}" > "${CONFIG_DIR}"/vm02_initiatorname.iscsi
+  echo "InitiatorName=${IQN}:${VM03_ISCSI_INITIATOR}" > "${CONFIG_DIR}"/vm03_initiatorname.iscsi
+}
+
 write_config_files() {
   write_hosts
   write_corosync_conf
+
+  if [[ "$ISCSI" == "YES" ]]; then
+    write_iscsi_initiator_conf_files
+  fi
 }
 
 generate_ssh_key_in_the_host() {
@@ -124,6 +182,12 @@ copy_ssh_key_to_all_nodes() {
 copy_config_files_to_all_nodes() {
   copy_to_all_nodes "${CONFIG_DIR}"/hosts
   copy_to_all_nodes "${CONFIG_DIR}"/corosync.conf
+
+  if [[ "$ISCSI" == "YES" ]]; then
+    copy_to_node "${IP_VM01}" "${CONFIG_DIR}"/vm01_initiatorname.iscsi
+    copy_to_node "${IP_VM02}" "${CONFIG_DIR}"/vm02_initiatorname.iscsi
+    copy_to_node "${IP_VM03}" "${CONFIG_DIR}"/vm03_initiatorname.iscsi
+  fi
 }
 
 wait_until_all_nodes_are_ready() {
@@ -132,10 +196,35 @@ wait_until_all_nodes_are_ready() {
   block_until_cloud_init_is_done "${IP_VM03}"
 }
 
+install_extra_packages() {
+  if [[ "$ISCSI" == "YES" ]]; then
+    run_in_all_nodes 'sudo apt-get install -y open-iscsi'
+  fi
+}
+
 setup_config_files_in_all_nodes() {
+  if [[ "$ISCSI" == "YES" ]]; then
+    run_command_in_node "${IP_VM01}" "sudo cp /home/ubuntu/vm01_initiatorname.iscsi /etc/iscsi/initiatorname.iscsi"
+    run_command_in_node "${IP_VM02}" "sudo cp /home/ubuntu/vm02_initiatorname.iscsi /etc/iscsi/initiatorname.iscsi"
+    run_command_in_node "${IP_VM03}" "sudo cp /home/ubuntu/vm03_initiatorname.iscsi /etc/iscsi/initiatorname.iscsi"
+
+    run_in_all_nodes "sudo systemctl restart open-iscsi iscsid"
+  fi
+
   run_in_all_nodes 'sudo cp /home/ubuntu/hosts /etc/'
   run_in_all_nodes 'sudo cp /home/ubuntu/corosync.conf /etc/corosync/'
   run_in_all_nodes 'sudo systemctl restart corosync'
+}
+
+login_iscsi_target() {
+  run_in_all_nodes "sudo iscsiadm -m discovery -t sendtargets -p ${IP_VM_SERVICES}"
+  run_in_all_nodes "sudo iscsiadm -m node --login"
+}
+
+configure_service_vm() {
+  if [[ "$ISCSI" == "YES" ]]; then
+    login_iscsi_target
+  fi
 }
 
 check_if_all_nodes_are_online() {
@@ -153,6 +242,7 @@ check_if_all_nodes_are_online() {
 }
 
 check_requirements
+setup_service_vm
 create_nodes
 get_nodes_ip_address
 write_config_files
@@ -161,5 +251,7 @@ verify_all_nodes_reachable_via_ssh
 copy_ssh_key_to_all_nodes
 copy_config_files_to_all_nodes
 wait_until_all_nodes_are_ready
+install_extra_packages
 setup_config_files_in_all_nodes
+configure_service_vm
 check_if_all_nodes_are_online

--- a/ha/virsh/vm_utils.sh
+++ b/ha/virsh/vm_utils.sh
@@ -87,3 +87,11 @@ find_node_to_move_resource() {
       ;;
   esac
 }
+
+block_until_cloud_init_is_done() {
+  NODE="${1}"
+
+  # set debconf frontend to Noninteractive
+  run_command_in_node "${NODE}" "echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections"
+  run_command_in_node "${NODE}" "cloud-init status --wait"
+}

--- a/ha/virsh/vm_utils.sh
+++ b/ha/virsh/vm_utils.sh
@@ -2,12 +2,24 @@
 
 UBUNTU_SERIES="${UBUNTU_SERIES:-impish}"
 
+VM_SERVICES="services-${UBUNTU_SERIES}"
+IQN="iqn.$(date '+%Y-%m').com.test.storage"
+
+VM_SERVICES_ISCSI_TARGET="target01"
+VM01_ISCSI_INITIATOR="initiator01"
+VM02_ISCSI_INITIATOR="initiator02"
+VM03_ISCSI_INITIATOR="initiator03"
+
 VM01="fence-test-virsh-${UBUNTU_SERIES}-node01"
 VM02="fence-test-virsh-${UBUNTU_SERIES}-node02"
 VM03="fence-test-virsh-${UBUNTU_SERIES}-node03"
 
 SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
 SCP="scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+
+get_vm_services_ip_address() {
+  IP_VM_SERVICES=$(virsh domifaddr "${VM_SERVICES}" | grep ipv4 | xargs | cut -d ' ' -f4 | cut -d '/' -f1)
+}
 
 get_all_nodes_ip_address() {
   IP_VM01=$(virsh domifaddr "${VM01}" | grep ipv4 | xargs | cut -d ' ' -f4 | cut -d '/' -f1)

--- a/ha/virsh/vm_utils.sh
+++ b/ha/virsh/vm_utils.sh
@@ -31,8 +31,14 @@ run_in_all_nodes() {
 copy_to_all_nodes() {
   FILE="${1}"
   for node_ip in "${IP_VM01}" "${IP_VM02}" "${IP_VM03}"; do
-    ${SCP} "${FILE}" ubuntu@"${node_ip}":/home/ubuntu/
+    copy_to_node "${node_ip}" "${FILE}"
   done
+}
+
+copy_to_node() {
+  NODE="${1}"
+  FILE="${2}"
+  ${SCP} "${FILE}" ubuntu@"${NODE}":/home/ubuntu/
 }
 
 get_name_node_running_resource() {


### PR DESCRIPTION
The proposed changes add a `--iscsi` option to `setup-cluster.sh`, it will create a separate VM to be used as an iscsi target (in the future it could be used for other external services) and configure all the cluster nodes as iscsi initiators. If this new option is not passed to the script the old behavior will be the same.

If you want to test you can run `setup-cluster.sh --iscsi`, ssh into any cluster node and check if the iscsi block device is there:

```
ubuntu@fence-test-virsh-impish-node01:~$ sudo lsblk --scsi
NAME HCTL       TYPE VENDOR   MODEL         REV SERIAL                               TRAN
sda  6:0:0:0    disk LIO-ORG  iscsi-disk01 4.0  2f87b5b9-7f8a-49d3-9f85-d917a48c5c66 iscsi
ubuntu@fence-test-virsh-impish-node01:~$ cat /proc/partitions 
major minor  #blocks  name

   7        0      56780 loop0
   7        1      70848 loop1
   7        2      33048 loop2
 252        0   10485760 vda
 252        1   10372079 vda1
 252       14       4096 vda14
 252       15     108544 vda15
 252       16        366 vdb
 252       32    1048576 vdc
   8        0    1048576 sda
```

In this case `/dev/sda` is what we are looking for, and this is a disk provided by the iscsi target (running in the services VM) and shared by the iscsi initiators.