### PR TITLE
HA: rename VMs name, define the name based also on the agent name

### DIFF
--- a/ha/virsh/delete-cluster.sh
+++ b/ha/virsh/delete-cluster.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 : "${UBUNTU_SERIES:=impish}"
-VM_PREFIX="fence-test-virsh-${UBUNTU_SERIES}-node"
+VM_PREFIX="ha-agent-virsh-${UBUNTU_SERIES}-${AGENT}-node"
 VM_SERVICES="services-${UBUNTU_SERIES}"
 
 # Remove all cluster nodes

--- a/ha/virsh/run_tests.sh
+++ b/ha/virsh/run_tests.sh
@@ -9,6 +9,7 @@ source /etc/profile.d/libvirt-uri.sh
 
 test_failed=0
 for file in $TESTS; do
+  export AGENT=$(echo $file | grep -oP '(?<=/).+(?=\_)')
   ./setup-cluster.sh
   if ! bash "$file"; then
     test_failed=1

--- a/ha/virsh/vm_utils.sh
+++ b/ha/virsh/vm_utils.sh
@@ -10,9 +10,9 @@ VM01_ISCSI_INITIATOR="initiator01"
 VM02_ISCSI_INITIATOR="initiator02"
 VM03_ISCSI_INITIATOR="initiator03"
 
-VM01="fence-test-virsh-${UBUNTU_SERIES}-node01"
-VM02="fence-test-virsh-${UBUNTU_SERIES}-node02"
-VM03="fence-test-virsh-${UBUNTU_SERIES}-node03"
+VM01="ha-agent-virsh-${UBUNTU_SERIES}-${AGENT}-node01"
+VM02="ha-agent-virsh-${UBUNTU_SERIES}-${AGENT}-node02"
+VM03="ha-agent-virsh-${UBUNTU_SERIES}-${AGENT}-node03"
 
 SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
 SCP="scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"


### PR DESCRIPTION
It allows parallel executions of the tests by the Jenkins jobs.

This is the implementation of what was described here: https://github.com/canonical/server-jenkins-jobs/pull/199#issuecomment-868529993