### PR TITLE
Revert "Temporarily add my PPA to install the new fence-agents package"

### DIFF
--- a/ha/virsh/create-vm.sh
+++ b/ha/virsh/create-vm.sh
@@ -66,9 +66,6 @@ apt:
   sources:
     proposed.list:
       source: "deb http://archive.ubuntu.com/ubuntu ${UBUNTU_SERIES}-proposed main universe"
-    ha-agents-split.list:
-      source: "deb http://ppa.launchpad.net/lucaskanashiro/ha-stack/ubuntu ${UBUNTU_SERIES} main"
-      keyid: 5E6FEC392228FFDB9804C3A7F2AA00BB605DABB3
 package_update: true
 packages: ['corosync', 'pacemaker', 'pacemaker-cli-utils', 'crmsh', 'resource-agents-base', 'fence-agents-base']
 EOF


### PR DESCRIPTION
This reverts commit 1a438f342615bfb96595ae7cba081b2b55a9953f.

The new fence-agents package is already in impish-proposed.