### PR TITLE
HA: fix curl calls in systemd resource agent tests

### DIFF
--- a/ha/virsh/run_tests.sh
+++ b/ha/virsh/run_tests.sh
@@ -9,10 +9,10 @@ source /etc/profile.d/libvirt-uri.sh
 
 test_failed=0
 for file in $TESTS; do
-  AGENT=$(echo "$file" | grep -oP '(?<=/).+(?=\_)')
+  AGENT=$(echo "$file" | grep -oP '(?<=/).+(?=\_)' | tr _ -)
   export AGENT=$AGENT
 
-  if [[ "$AGENT" == "fence_scsi" ]]; then
+  if [[ "$AGENT" == "fence-scsi" ]]; then
     ./setup-cluster.sh --iscsi
   else
     ./setup-cluster.sh

--- a/ha/virsh/tests/resource_systemd_test.sh
+++ b/ha/virsh/tests/resource_systemd_test.sh
@@ -27,6 +27,14 @@ oneTimeSetUp() {
   setup_systemd_service
 
   readonly RESOURCE_NAME="gethostname-service"
+
+  # After version 7.66.0 the support to HTTP 0.9 was disabled by default
+  curl_version=$(curl --version | grep -m1 curl | cut -d ' ' -f 2)
+  if dpkg --compare-versions "$curl_version" gt "7.66.0"; then
+    CURL="curl --http0.9 --silent"
+  else
+    CURL="curl --silent"
+  fi
 }
 
 configure_cluster_properties() {
@@ -52,7 +60,7 @@ test_systemd_resource_is_started() {
 test_if_hostname_is_correct() {
   find_node_running_resource "${RESOURCE_NAME}"
 
-  running_node=$(curl --silent "${IP_RESOURCE}":8080)
+  running_node=$(${CURL} ${IP_RESOURCE}:8080)
   [[ "${running_node}" == *"${VM_RESOURCE}"* ]]
   assertTrue $?
 }
@@ -70,13 +78,13 @@ test_move_resource() {
   assertTrue $?
 
   # Check if the systemd service is running in the target node
-  running_node=$(curl --silent "${IP_TARGET}":8080)
+  running_node=$(${CURL} ${IP_TARGET}:8080)
   [[ "${running_node}" == *"${VM_TARGET}"* ]]
   assertTrue $?
 
   # Make sure the service is not running on the previous node
   running_in_previous_node=0
-  if curl --silent "${VM_RESOURCE}":8080; then
+  if ${CURL} ${VM_RESOURCE}:8080; then
     running_in_previous_node=1
   fi
   assertTrue "${running_in_previous_node}"


### PR DESCRIPTION
Those changes were tested in `dugtrio` and also in my host running Focal, everything seems to be working fine for me.