### PR TITLE
HA: add an extra network interface to all VMs

### DIFF
--- a/ha/virsh/delete-cluster.sh
+++ b/ha/virsh/delete-cluster.sh
@@ -3,6 +3,7 @@
 : "${UBUNTU_SERIES:=impish}"
 VM_PREFIX="ha-agent-virsh-${UBUNTU_SERIES}-${AGENT}-node"
 VM_SERVICES="services-${UBUNTU_SERIES}"
+HA_NETWORK="ha"
 
 # Remove all cluster nodes
 virsh list --state-running --name | grep "^$VM_PREFIX" | xargs -L 1 --no-run-if-empty virsh destroy
@@ -12,6 +13,12 @@ virsh list --state-shutoff --name | grep "^$VM_PREFIX" | xargs -L 1 --no-run-if-
 if virsh list --name | grep ${VM_SERVICES}; then
   virsh destroy ${VM_SERVICES}
   virsh undefine --remove-all-storage ${VM_SERVICES}
+fi
+
+# Remove the HA specific network
+if virsh net-list --name | grep ${HA_NETWORK}; then
+  virsh net-destroy "${HA_NETWORK}"
+  virsh net-undefine "${HA_NETWORK}"
 fi
 
 # Check for leftover VMs (cleanup failed!)

--- a/ha/virsh/setup-cluster.sh
+++ b/ha/virsh/setup-cluster.sh
@@ -41,7 +41,7 @@ check_requirements() {
 create_service_vm() {
   ${CREATE_VM_SCRIPT} "${VM_SERVICES}" "$(pwd)"
   sleep 60
-  get_vm_services_ip_address
+  get_vm_services_ip_addresses
   block_until_cloud_init_is_done "${IP_VM_SERVICES}"
 }
 
@@ -69,9 +69,16 @@ create_nodes() {
   virsh list
 }
 
-get_nodes_ip_address() {
+get_nodes_ip_addresses() {
   sleep 30
-  get_all_nodes_ip_address
+  get_all_nodes_ip_addresses
+
+  # Get IP address in the second network interface. For some reason this is not
+  # done automatically during VM creation.
+  for ip in "${IP_VM01}" "${IP_VM02}" "${IP_VM03}"; do
+    network_interface=$(get_name_second_nic "${ip}")
+    run_command_in_node "${ip}" "sudo dhclient ${network_interface}"
+  done
 }
 
 write_hosts() {
@@ -244,7 +251,7 @@ check_if_all_nodes_are_online() {
 check_requirements
 setup_service_vm
 create_nodes
-get_nodes_ip_address
+get_nodes_ip_addresses
 write_config_files
 generate_ssh_key_in_the_host
 verify_all_nodes_reachable_via_ssh

--- a/ha/virsh/tests/fence_scsi_test.sh
+++ b/ha/virsh/tests/fence_scsi_test.sh
@@ -6,7 +6,7 @@
 . "$(dirname "$0")/../vm_utils.sh"
 
 oneTimeSetUp() {
-  get_all_nodes_ip_address
+  get_all_nodes_ip_addresses
 
   readonly RESOURCE_NAME="fence-scsi"
   readonly SCSI_DEVICE="/dev/sda"

--- a/ha/virsh/tests/fence_virsh_test.sh
+++ b/ha/virsh/tests/fence_virsh_test.sh
@@ -6,7 +6,7 @@
 . "$(dirname "$0")/../vm_utils.sh"
 
 oneTimeSetUp() {
-  get_all_nodes_ip_address
+  get_all_nodes_ip_addresses
 
   readonly HOST_IP="192.168.122.1"
   readonly HOST_USER="${USER}"

--- a/ha/virsh/tests/resource_ipaddr2_test.sh
+++ b/ha/virsh/tests/resource_ipaddr2_test.sh
@@ -6,7 +6,7 @@
 . "$(dirname "$0")/../vm_utils.sh"
 
 oneTimeSetUp() {
-  get_all_nodes_ip_address
+  get_all_nodes_ip_addresses
 
   readonly FLOATING_IP="192.168.122.255"
   readonly NETMASK="24"

--- a/ha/virsh/tests/resource_lvm-activate_test.sh
+++ b/ha/virsh/tests/resource_lvm-activate_test.sh
@@ -20,7 +20,7 @@ setup_lvm() {
 }
 
 oneTimeSetUp() {
-  get_all_nodes_ip_address
+  get_all_nodes_ip_addresses
 
   readonly RESOURCE_NAME="lvm2-activator"
   readonly VG="clustervg"

--- a/ha/virsh/tests/resource_systemd_test.sh
+++ b/ha/virsh/tests/resource_systemd_test.sh
@@ -23,7 +23,7 @@ EOF
 }
 
 oneTimeSetUp() {
-  get_all_nodes_ip_address
+  get_all_nodes_ip_addresses
   setup_systemd_service
 
   readonly RESOURCE_NAME="gethostname-service"


### PR DESCRIPTION
This is a preparation to test the multipath fence agent. To have a minimal multipath setup we need at least 2 network interfaces in each node so that we can reach the target via different paths.

With that said, I added changes to create a new network using virsh and added it to all VMs. The only thing that I did not figure out how to fix it properly is to get an IP address in this second network interface, at the moment I am calling `dhclient` to assign an IP address to it, if you have a better solution for that, I'll be happy to incorporate to this PR.

And I also ran all the tests locally using this branch and all of them passed.