### PR TITLE
OCI: Check whether the manifest file(s) is(are) empty

### DIFF
--- a/oci-unit-tests/apache2_test.sh
+++ b/oci-unit-tests/apache2_test.sh
@@ -102,7 +102,7 @@ test_manifest_exists() {
     container=$(docker_run_server)
 
     check_manifest_exists "${container}"
-    assertTrue "Manifest file(s) do(es) not exist in image" $?
+    assertTrue "Manifest file(s) do(es) not exist or is(are) empty in image" $?
 }
 
 load_shunit2

--- a/oci-unit-tests/cassandra_test.sh
+++ b/oci-unit-tests/cassandra_test.sh
@@ -133,7 +133,7 @@ test_manifest_exists() {
     container=$(docker_run_server)
 
     check_manifest_exists "${container}"
-    assertTrue "Manifest file(s) do(es) not exist in image" $?
+    assertTrue "Manifest file(s) do(es) not exist or is(are) empty in image" $?
 }
 
 load_shunit2

--- a/oci-unit-tests/cortex_test.sh
+++ b/oci-unit-tests/cortex_test.sh
@@ -77,7 +77,7 @@ test_manifest_exists() {
     container=$(docker_run_cortex)
 
     check_manifest_exists "${container}"
-    assertTrue "Manifest file(s) do(es) not exist in image" $?
+    assertTrue "Manifest file(s) do(es) not exist or is(are) empty in image" $?
 }
 
 load_shunit2

--- a/oci-unit-tests/grafana_test.sh
+++ b/oci-unit-tests/grafana_test.sh
@@ -109,7 +109,7 @@ test_manifest_exists() {
     container=$(docker_run_server)
 
     check_manifest_exists "${container}"
-    assertTrue "Manifest file(s) do(es) not exist in image" $?
+    assertTrue "Manifest file(s) do(es) not exist or is(are) empty in image" $?
 }
 
 load_shunit2

--- a/oci-unit-tests/memcached_test.sh
+++ b/oci-unit-tests/memcached_test.sh
@@ -142,7 +142,7 @@ test_manifest_exists() {
     container=$(docker_run_server)
 
     check_manifest_exists "${container}"
-    assertTrue "Manifest file(s) do(es) not exist in image" $?
+    assertTrue "Manifest file(s) do(es) not exist or is(are) empty in image" $?
 }
 
 load_shunit2

--- a/oci-unit-tests/mysql_test.sh
+++ b/oci-unit-tests/mysql_test.sh
@@ -205,7 +205,7 @@ test_manifest_exists() {
     container=$(docker_run_server -e MYSQL_ROOT_PASSWORD="${password}")
 
     check_manifest_exists "${container}"
-    assertTrue "Manifest file(s) do(es) not exist in image" $?
+    assertTrue "Manifest file(s) do(es) not exist or is(are) empty in image" $?
 }
 
 load_shunit2

--- a/oci-unit-tests/nginx_test.sh
+++ b/oci-unit-tests/nginx_test.sh
@@ -145,7 +145,7 @@ test_manifest_exists() {
     container=$(docker_run_server)
 
     check_manifest_exists "${container}"
-    assertTrue "Manifest file(s) do(es) not exist in image" $?
+    assertTrue "Manifest file(s) do(es) not exist or is(are) empty in image" $?
 }
 
 load_shunit2

--- a/oci-unit-tests/postgres_test.sh
+++ b/oci-unit-tests/postgres_test.sh
@@ -215,7 +215,7 @@ test_manifest_exists() {
     )
 
     check_manifest_exists "${container}"
-    assertTrue "Manifest file(s) do(es) not exist in image" $?
+    assertTrue "Manifest file(s) do(es) not exist or is(are) empty in image" $?
 }
 
 load_shunit2

--- a/oci-unit-tests/prometheus-alertmanager_test.sh
+++ b/oci-unit-tests/prometheus-alertmanager_test.sh
@@ -88,7 +88,7 @@ test_manifest_exists() {
     container=$(docker_run_alertmanager)
 
     check_manifest_exists "${container}"
-    assertTrue "Manifest file(s) do(es) not exist in image" $?
+    assertTrue "Manifest file(s) do(es) not exist or is(are) empty in image" $?
 }
 
 load_shunit2

--- a/oci-unit-tests/prometheus_test.sh
+++ b/oci-unit-tests/prometheus_test.sh
@@ -290,7 +290,7 @@ test_manifest_exists() {
     container=$(docker_run_prom)
 
     check_manifest_exists "${container}"
-    assertTrue "Manifest file(s) do(es) not exist in image" $?
+    assertTrue "Manifest file(s) do(es) not exist or is(are) empty in image" $?
 }
 
 load_shunit2

--- a/oci-unit-tests/redis_test.sh
+++ b/oci-unit-tests/redis_test.sh
@@ -202,7 +202,7 @@ test_manifest_exists() {
     container=$(docker_run_server -e ALLOW_EMPTY_PASSWORD=yes)
 
     check_manifest_exists "${container}"
-    assertTrue "Manifest file(s) do(es) not exist in image" $?
+    assertTrue "Manifest file(s) do(es) not exist or is(are) empty in image" $?
 }
 
 load_shunit2

--- a/oci-unit-tests/telegraf_test.sh
+++ b/oci-unit-tests/telegraf_test.sh
@@ -104,7 +104,7 @@ test_manifest_exists() {
     container=$(docker_run_telegraf)
 
     check_manifest_exists "${container}"
-    assertTrue "Manifest file(s) do(es) not exist in image" $?
+    assertTrue "Manifest file(s) do(es) not exist or is(are) empty in image" $?
 }
 
 load_shunit2


### PR DESCRIPTION
Athos has recently worked on (and fixed) a bug on the golang manifest
generator script which rendered empty manifest files for some images.
Apparently this bug has silently crept in some time ago, and we didn't
notice.  I thought that it'd be useful to expand our current
"is-the-manifest-file-present" unit test and make it also error if the
manifest file is empty (which should never happen).

I wasn't entirely sure whether this should be a new test or not, but I
think it makes sense (and is cleaner) to do it in the existing test.