### PR TITLE
oci cassandra: do not `docker run` in interactive mode

### DIFF
--- a/oci-unit-tests/cassandra_test.sh
+++ b/oci-unit-tests/cassandra_test.sh
@@ -62,7 +62,7 @@ docker_run_client() {
     docker run \
      --network "$DOCKER_NETWORK" \
      --rm \
-     -it \
+     --tty \
      --name cqlsh_test_${id} \
      -v "${cqlsh_file}":/hello-cassandra.cqlsh \
      "${CQLSH_DOCKER_IMAGE}" \


### PR DESCRIPTION
Do not `docker run` in interactive mode (drop the `-i`) but do allocate
a tty (`--tty`) so we can get stdout from the run command.
