### PR TITLE
OCI: Fallback to local cqlsh builds

### DIFF
--- a/oci-unit-tests/cassandra_test.sh
+++ b/oci-unit-tests/cassandra_test.sh
@@ -12,7 +12,7 @@
 #  setUp() - run before each test
 #  tearDown() - run after each test
 
-readonly CQLSH_DOCKER_IMAGE="docker.io/cassandra:latest"
+readonly CQLSH_DOCKER_IMAGE="cassandra-cqlsh:test"
 
 oneTimeSetUp() {
     id=$$
@@ -25,8 +25,8 @@ oneTimeSetUp() {
 
     docker network create "$DOCKER_NETWORK" > /dev/null 2>&1
 
-    # pull image with cqlsh client
-    docker pull --quiet "${CQLSH_DOCKER_IMAGE}" > /dev/null
+    # build image with cqlsh client
+    docker build -t $CQLSH_DOCKER_IMAGE ./cassandra_test_data > /dev/null 2>&1
 }
 
 oneTimeTearDown() {
@@ -66,7 +66,6 @@ docker_run_client() {
      --name cqlsh_test_${id} \
      -v "${cqlsh_file}":/hello-cassandra.cqlsh \
      "${CQLSH_DOCKER_IMAGE}" \
-     cqlsh \
      cassandra_test_${id} \
      "$@"
 }

--- a/oci-unit-tests/cassandra_test.sh
+++ b/oci-unit-tests/cassandra_test.sh
@@ -69,7 +69,7 @@ docker_run_server() {
 # Helper function to execute cqlsh with some common arguments.
 docker_run_client() {
     # mount data into the container
-    cqlsh_file="$(realpath $(dirname "$0"))/cassandra_test_data/hello-cassandra.cqlsh"
+    cqlsh_file="$(realpath "$(dirname "$0")")/cassandra_test_data/hello-cassandra.cqlsh"
     docker run \
      --network "$DOCKER_NETWORK" \
      --rm \

--- a/oci-unit-tests/cassandra_test_data/Dockerfile
+++ b/oci-unit-tests/cassandra_test_data/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:impish
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get full-upgrade -y && \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+		git python3-pip build-essential python3-dev && \
+	git clone https://github.com/apache/cassandra.git && \
+	cd cassandra/pylib && pip install Cython && pip install -r requirements.txt && pip install .
+WORKDIR /cassandra
+ENTRYPOINT ["bin/cqlsh"]

--- a/oci-unit-tests/cassandra_test_data/Dockerfile
+++ b/oci-unit-tests/cassandra_test_data/Dockerfile
@@ -4,5 +4,5 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get full-upgrade -y && 
 		git python3-pip build-essential python3-dev && \
 	git clone https://github.com/apache/cassandra.git && \
 	cd cassandra/pylib && pip install Cython && pip install -r requirements.txt && pip install .
+ENV PATH="/cassandra/bin:${PATH}"
 WORKDIR /cassandra
-ENTRYPOINT ["bin/cqlsh"]


### PR DESCRIPTION
Let's use the official Cassandra image as a source for the cqlsh CLI application. In case the image is not available for a given platform, we then fallback to building a cqlsh image locally. This is a compromise between saving CI resources when possible and still ensuring we will have an image with cqlsh to test Cassandra.

This fixes the tests for Cassandra in s390x, where upstream cassandra images are not available.