### PR TITLE
OCI: Consolidate `$ROOTDIR` usage (and fix a few pending issues)

### DIFF
--- a/oci-unit-tests/apache2_test.sh
+++ b/oci-unit-tests/apache2_test.sh
@@ -70,7 +70,7 @@ test_default_config_ipv6() {
 
 test_static_content() {
     debug "Creating all-defaults apache2 container"
-    test_data_wwwroot="$(realpath -e $(dirname "$0"))/apache2_test_data/html"
+    test_data_wwwroot="${ROOTDIR}/apache2_test_data/html"
     container=$(docker_run_server -p "$LOCAL_PORT:80" -v "$test_data_wwwroot:/var/www/html:ro")
 
     assertNotNull "Failed to start the container" "${container}" || return 1
@@ -84,8 +84,8 @@ test_static_content() {
 
 test_custom_config() {
     debug "Creating apache2 container with custom config"
-    custom_config="$(realpath -e $(dirname "$0"))/apache2_test_data/apache2_simple.conf"
-    test_data_wwwroot="$(realpath -e $(dirname "$0"))/apache2_test_data/html"
+    custom_config="${ROOTDIR}/apache2_test_data/apache2_simple.conf"
+    test_data_wwwroot="${ROOTDIR}/apache2_test_data/html"
     container=$(docker_run_server -p "$LOCAL_PORT:80" -v "$custom_config:/etc/apache2/apache2.conf:ro" -v "$test_data_wwwroot:/srv/www:ro")
 
     assertNotNull "Failed to start the container" "${container}" || return 1

--- a/oci-unit-tests/cassandra_test.sh
+++ b/oci-unit-tests/cassandra_test.sh
@@ -69,7 +69,7 @@ docker_run_server() {
 # Helper function to execute cqlsh with some common arguments.
 docker_run_client() {
     # mount data into the container
-    cqlsh_file="$(realpath "$(dirname "$0")")/cassandra_test_data/hello-cassandra.cqlsh"
+    cqlsh_file="${ROOTDIR}/cassandra_test_data/hello-cassandra.cqlsh"
     docker run \
      --network "$DOCKER_NETWORK" \
      --rm \

--- a/oci-unit-tests/helper/test_helper.sh
+++ b/oci-unit-tests/helper/test_helper.sh
@@ -1,8 +1,7 @@
 # shellcheck shell=dash
 
-PATH="$(dirname "$0")/..:$PATH"
-ROOTDIR="$(dirname "$0")/.."
-export PATH ROOTDIR
+ROOTDIR=$(realpath -e "$(dirname "$0")")
+export ROOTDIR
 
 load_shunit2() {
   if [ -e /usr/share/shunit2/shunit2 ]; then

--- a/oci-unit-tests/nginx_test.sh
+++ b/oci-unit-tests/nginx_test.sh
@@ -77,7 +77,7 @@ test_default_config_ipv6() {
 
 test_static_files() {
     debug "Creating container with known static files"
-    test_data_wwwroot="$PWD/nginx_test_data/html"
+    test_data_wwwroot="${ROOTDIR}/nginx_test_data/html"
     container=$(docker_run_server -p 48080:80 -v "$test_data_wwwroot:/var/www/html:ro")
 
     assertNotNull "Failed to start the container" "${container}" || return 1
@@ -91,7 +91,7 @@ test_static_files() {
 
 test_static_files_read_only_mode() {
     debug "Creating container with known static files"
-    test_data_wwwroot="$PWD/nginx_test_data/html"
+    test_data_wwwroot="${ROOTDIR}/nginx_test_data/html"
     nginx_scratch=$(mktemp -d /tmp/nginx-cache-XXXXXXXX)
     container=$(docker_run_server -p 48080:80 --read-only -v "$nginx_scratch:/var/lib/nginx" -v "$nginx_scratch:/var/log/nginx" -v "$nginx_scratch:/var/run" -v "$test_data_wwwroot:/var/www/html:ro")
 
@@ -108,8 +108,8 @@ test_static_files_read_only_mode() {
 
 test_custom_config() {
     debug "Creating container with custom config"
-    custom_config="$PWD/nginx_test_data/nginx_simple.conf"
-    test_data_wwwroot="$PWD/nginx_test_data/html"
+    custom_config="${ROOTDIR}/nginx_test_data/nginx_simple.conf"
+    test_data_wwwroot="${ROOTDIR}/nginx_test_data/html"
     container=$(docker_run_server -p 48080:80 -v "$custom_config:/etc/nginx/nginx.conf:ro" -v "$test_data_wwwroot:/srv/www/html:ro")
 
     assertNotNull "Failed to start the container" "${container}" || return 1
@@ -132,7 +132,7 @@ test_reverse_proxy() {
     assertEquals "${orig_checksum}" "${retrieved_checksum}"
 
     debug "Creating reverse proxy nginx container"
-    rp_config="$PWD/nginx_test_data/nginx_reverse_proxy.conf"
+    rp_config="${ROOTDIR}/nginx_test_data/nginx_reverse_proxy.conf"
     rp_container=$(docker_run_server --network "${DOCKER_NETWORK}" -p 48070:48070 -v "$rp_config:/etc/nginx/nginx.conf:ro")
     assertNotNull "Failed to start the container" "${rp_container}" || return 1
     wait_nginx_container_ready "${rp_container}" || return 1

--- a/oci-unit-tests/telegraf_test.sh
+++ b/oci-unit-tests/telegraf_test.sh
@@ -85,7 +85,7 @@ test_telegraf_custom_config_http_endpoint() {
     # GNU/Linux doesn't.
     container=$(docker_run_telegraf \
 		    --network=host \
-		    -v "$PWD"/telegraf_test_data/telegraf.conf:/etc/telegraf/telegraf.conf)
+		    -v "${ROOTDIR}"/telegraf_test_data/telegraf.conf:/etc/telegraf/telegraf.conf)
     assertNotNull "Failed to start the container" "${container}" || return 1
     wait_telegraf_container_ready "${container}" || return 1
 


### PR DESCRIPTION
I was testing the new telegraf OCI image for 21.10 from inside the
image's repository (i.e., I was invoking the unittest script while
outside its working directory), and noticed that the test was failing
because it was using `$PWD` indiscriminately.

I took the opportunity to improve the handling of these scenarios.  We
already had a `$ROOTDIR` variable being declared in the test_helper.sh
script, but it contained the wrong value and wasn't being used by
anyone.  I fixed it and converted the existing calls to `$(dirname
"$0")` and made them use `$ROOTDIR` instead.  While at it, I have also
removed the needless `$PATH` manipulation that was being done in the
same script.