### PR TITLE
Bind9 tests

### DIFF
--- a/oci-unit-tests/README.md
+++ b/oci-unit-tests/README.md
@@ -8,15 +8,15 @@ with the `dash` implementation of `sh` (Ubuntu's default).
 
 ### Test dependencies
 
-The tests should run on any Ubuntu >=Bionic system. Other than all the
+The tests should run on any Ubuntu >= Bionic system. Other than all the
 `Priority: required` packages the tests can assume the following packages
-an all of their dependencies are installed on the host system:
+and all of their dependencies are installed on the host system:
 
  - `ubuntu-server`
  - `docker.io`
  - `shunit2`
 
-If a test requires specific dependencies they should be installed in a
+If a test requires specific dependencies it should be installed in a
 dedicated Docker container.
 
 ### Port allocation
@@ -24,7 +24,7 @@ dedicated Docker container.
 Many OCI unit tests require listening on local ports on the host system. Tests
 should use ports in the
 [Dynamic Ports range](https://tools.ietf.org/html/rfc6335#section-8.1.2)
-(49152-65535). When writing a new tests care should be taken not to re-use a
+(49152-65535). When writing a new test, care should be taken not to re-use a
 port already used by another test.
 
 ## Jenkins

--- a/oci-unit-tests/bind9_test.sh
+++ b/oci-unit-tests/bind9_test.sh
@@ -1,0 +1,104 @@
+# shellcheck shell=dash
+
+# shellcheck disable=SC1090
+. "$(dirname "$0")/helper/test_helper.sh"
+. "$(dirname "$0")/helper/common_vars.sh"
+
+# cheat sheet:
+#  assertTrue $?
+#  assertEquals ["explanation"] 1 2
+#  oneTimeSetUp()
+#  oneTimeTearDown()
+#  setUp() - run before each test
+#  tearDown() - run after each test
+
+oneTimeSetUp() {
+    # Remove image before test.
+    remove_current_image
+
+    # Make sure we're using the latest OCI image.
+    docker pull --quiet "${DOCKER_IMAGE}" > /dev/null 2>&1
+
+    # Cleanup stale resources
+    tearDown
+    oneTimeTearDown
+
+    # Setup network
+    docker network create "${DOCKER_NETWORK}" > /dev/null 2>&1
+}
+
+oneTimeTearDown() {
+    docker network rm "${DOCKER_NETWORK}" > /dev/null 2>&1
+}
+
+tearDown() {
+    local container
+
+    for container in $(docker ps --filter "name=${DOCKER_PREFIX}" --format "{{.Names}}"); do
+        debug "Removing container ${container}"
+        stop_container_sync "${container}"
+    done
+}
+
+wait_bind9_container_ready() {
+    local container="${1}"
+    local log="running"
+    wait_container_ready "${container}" "${log}"
+}
+
+
+test_local_connection() {
+    local container
+
+    debug "Creating all-defaults bind9 container"
+    container=$(run_container_service)
+    assertNotNull "Failed to start the container" "${container}" || return 1
+
+    wait_bind9_container_ready "${container}" || return 1
+
+    debug "Installing test dependencies locally"
+    install_container_packages "${container}" "lsof" || return 1
+
+    debug "Checking for service on local port 53"
+    docker exec "${container}" lsof -i:53 | grep -q LISTEN
+
+    assertTrue ${?}
+}
+
+test_network_connection() {
+    local container_server
+    local container_client
+
+    debug "Creating all-defaults bind9 container (server)"
+    container_server=$(SUFFIX=server run_container_service)
+    assertNotNull "Failed to start the container" "${container_server}" || return 1
+
+    # Wait for server to be ready
+    wait_bind9_container_ready "${container_server}" || return 1
+
+    debug "Creating all-defaults bind9 container (client)"
+    container_client=$(SUFFIX=client run_container_service)
+    assertNotNull "Failed to start the container" "${container_client}" || return 1
+
+    # Wait for client to be ready
+    wait_bind9_container_ready "${container_client}" || return 1
+
+    debug "Installing test dependencies (client)"
+    install_container_packages "${container_client}" "bind9-dnsutils" || return 1
+
+    # Use dig from the client to the server's IP
+    docker exec "${container_client}" dig "${DOCKER_PREFIX}_server:30053" > /dev/null
+    assertTrue ${?}
+}
+
+test_manifest_exists() {
+    local container
+
+    debug "Testing that the manifest file is available in the image"
+    container=$(run_container_service)
+
+    check_manifest_exists "${container}"
+    assertTrue "Manifest file(s) do(es) not exist in image" ${?}
+}
+
+load_shunit2

--- a/oci-unit-tests/helper/test_helper.sh
+++ b/oci-unit-tests/helper/test_helper.sh
@@ -24,6 +24,42 @@ debug() {
     fi
 }
 
+# Creates a new docker container from $DOCKER_IMAGE.
+#
+# By default, creates a temporary container running the software under
+# test as a daemon service.  The container is automatically removed
+# when the daemon exits.  All parameters to run_container_service() are
+# passed directly through to the contained software daemon.  The docker
+# behavior can be adjusted through environmental variables listed
+# below.  In particular, $suffix can be used to distinguish between
+# multiple containers used in a given test, such as 'client' and
+# 'server'.
+#
+# Parameters:
+#   $@: parameters to pass through to the container
+# Environment:
+#   $DOCKER_IMAGE: Name of the image containing the software to be tested.
+#       Defaults to "docker.io/ubuntu/<package>:edge"
+#   $DOCKER_PREFIX: Common prefix for all containers for this test.
+#       Defaults to "oci_<package>_test".
+#   $DOCKER_NETWORK: User-created network to connect the container to.
+#       Defaults to "oci_<package>_test_net".
+#   $SUFFIX: Optional tag for ensuring unique container names.
+#       Defaults to a random string.
+#
+# Stdout: Name of created container.
+# Returns: Error code from docker, or 0 on success.
+run_container_service() {
+    SUFFIX=${SUFFIX:-$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 8 | head -n 1)}
+    docker run \
+       --network "${DOCKER_NETWORK}" \
+       --rm \
+       -d \
+       --name "${DOCKER_PREFIX}_${SUFFIX}" \
+       "${DOCKER_IMAGE}" \
+       "$@"
+}
+
 # $1: container id
 # $2: timeout (optional).  If not specified, defaults to 10 seconds
 stop_container_sync() {

--- a/oci-unit-tests/helper/test_helper.sh
+++ b/oci-unit-tests/helper/test_helper.sh
@@ -53,15 +53,15 @@ wait_container_ready() {
 
     debug -n "Waiting for container to be ready "
     while ! docker logs "${id}" 2>&1 | grep -qE "${msg}"; do
-	sleep 1
-	timeout=$((timeout - 1))
-	if [ $timeout -le 0 ]; then
-	    fail "ERROR, failed to start container ${id} in ${max} seconds"
-	    echo "Current container list (docker ps):"
-	    docker ps
-	    return 1
-	fi
-	debug -n "."
+        sleep 1
+        timeout=$((timeout - 1))
+        if [ $timeout -le 0 ]; then
+            fail "ERROR, failed to start container ${id} in ${max} seconds"
+            echo "Current container list (docker ps):"
+            docker ps
+            return 1
+        fi
+        debug -n "."
     done
     debug "done"
 }
@@ -79,19 +79,19 @@ check_manifest_exists()
     debug -n "Listing the manifest file(s) inside ${id}"
     local files
     if ! files=$(docker exec "${id}" ls "${manifest_dir}" 2> /dev/null); then
-	debug "not found"
-	return 1
+        debug "not found"
+        return 1
     fi
     debug "done"
 
     debug "Verifying whether the manifest file(s) exist"
     for want_file in ${possible_manifest_files}; do
-	for got_file in ${files}; do
-	    if [ "${got_file}" = "${want_file}" ]; then
-		debug "found ${got_file}"
-		found=1
-	    fi
-	done
+        for got_file in ${files}; do
+            if [ "${got_file}" = "${want_file}" ]; then
+                debug "found ${got_file}"
+                found=1
+            fi
+        done
     done
 
     if [ "${found}" -eq 0 ]; then

--- a/oci-unit-tests/helper/test_helper.sh
+++ b/oci-unit-tests/helper/test_helper.sh
@@ -103,6 +103,31 @@ wait_container_ready() {
 }
 
 # $1: container id
+# ${2...}: source package names to be installed
+install_container_packages()
+{
+    local retval=0
+    local id="${1}"
+    shift
+
+    docker exec -u root "${id}" apt-get -qy update > /dev/null
+    for package in "${@}"; do
+        debug "Installing ${package} into ${id}"
+        if docker exec -u root "${id}" \
+               apt-get -qy install "${package}" \
+               > /dev/null 2>&1;
+        then
+            debug "${package} installation succeeded"
+        else
+            fail "ERROR, failed to install '${package}' into ${id}"
+            retval=1
+        fi
+    done
+
+    return ${retval}
+}
+
+# $1: container id
 check_manifest_exists()
 {
     local id="${1}"

--- a/oci-unit-tests/memcached_test.sh
+++ b/oci-unit-tests/memcached_test.sh
@@ -103,8 +103,7 @@ test_libmemcached_compliance() {
     debug "Creating memcached container with libmemcached-tools"
     container_client=$(suffix=client docker_run_server)
     assertNotNull "Failed to start the container" "${container_client}" || return 1
-    docker exec -u root "$container_client" apt-get -qy update
-    docker exec -u root "$container_client" apt-get -qy --option=Dpkg::options::=--force-unsafe-io install libmemcached-tools
+    install_container_packages "${container_client}" "libmemcached-tools" || return 1
 
     docker exec "$container_client" memcping --servers="${DOCKER_PREFIX}_server"
     assertTrue $?
@@ -126,8 +125,7 @@ test_data_storage_and_retrieval() {
     assertNotNull "Failed to start the container" "${container_client}" || return 1
 
     debug "Installing libmemcached-tools"
-    docker exec -u root "$container_client" apt-get -q update
-    docker exec -u root "$container_client" apt-get -qy --option=Dpkg::options::=--force-unsafe-io install libmemcached-tools
+    install_container_packages "libmemcached-tools"
 
     debug "Running store/retrieve test"
     data="test data"


### PR DESCRIPTION
This adds some basic test cases for the new impish bind9 OCI image.  It does a local check that the service is present on the expected port, and a client/server test to check a trivial dns lookup.  This provides a similar level of coverage to what is available in the bind9 DEP8 tests.

Note that due to LP: #1943049 the bind9 image can't be built for impish, so I've been testing against a hirsute-built image.

Testing is performed via:

    DOCKER_IMAGE=test/bind9:edge sh ./bind9_test.sh

I also propose making a couple functions as helpers.  These are broken out as separate follow-on commits that can easily dropped or moved to other branches if desired.