### PR TITLE
ha run_test: do the pre-run cleanup when the AGENT is already known

### DIFF
--- a/ha/virsh/run_tests.sh
+++ b/ha/virsh/run_tests.sh
@@ -5,12 +5,13 @@
 # shellcheck disable=SC1091
 source /etc/profile.d/libvirt-uri.sh
 
-./delete-cluster.sh || exit 1
-
 test_failed=0
 for file in $TESTS; do
   AGENT=$(echo "$file" | grep -oP '(?<=/).+(?=\_)' | tr _ -)
   export AGENT=$AGENT
+
+  # Cleanup stale VMs
+  ./delete-cluster.sh || exit 1
 
   if [[ "$AGENT" == "fence-scsi" ]] || [[ "$AGENT" == "fence-mpath" ]]; then
     ./setup-cluster.sh --iscsi


### PR DESCRIPTION
The delete-cluster.sh scripts needs to know the AGENT being tested in
order to construct the VM_PREFIX to cleanup. This is known only within
the for loop iterating over TESTS. Move the delete-cluster.sh call
there.
