### PR TITLE
oci: sleep 5s on wait_container_ready()

### DIFF
--- a/oci-unit-tests/helper/test_helper.sh
+++ b/oci-unit-tests/helper/test_helper.sh
@@ -99,6 +99,7 @@ wait_container_ready() {
         fi
         debug -n "."
     done
+    sleep 5
     debug "done"
 }
 

--- a/oci-unit-tests/nginx_test.sh
+++ b/oci-unit-tests/nginx_test.sh
@@ -52,7 +52,6 @@ wait_nginx_container_ready() {
     local container="${1}"
     local log="Configuration complete"
     wait_container_ready "${container}" "${log}"
-    sleep 10
 }
 
 test_default_config() {


### PR DESCRIPTION
nginx is not the only image requiring some extra sleep time to make sure
the container is actually ready: squid is another example. Let's move
the sleep in the wait_container_ready() helper function; all the images
will get some extra time, but it won't hurt.
