### PR TITLE
oci: Verify required manifest files presence

### DIFF
--- a/oci-unit-tests/cassandra_test.sh
+++ b/oci-unit-tests/cassandra_test.sh
@@ -143,7 +143,7 @@ test_manifest_exists() {
     debug "Testing that the manifest file is available in the image"
     container=$(docker_run_server)
 
-    check_manifest_exists "${container}"
+    check_manifest_exists "${container}" manifest.yaml snapcraft.yaml
     assertTrue "Manifest file(s) do(es) not exist or is(are) empty in image" $?
 }
 

--- a/oci-unit-tests/cortex_test.sh
+++ b/oci-unit-tests/cortex_test.sh
@@ -75,7 +75,7 @@ test_manifest_exists() {
     debug "Testing that the manifest file is available in the image"
     container=$(docker_run_cortex)
 
-    check_manifest_exists "${container}"
+    check_manifest_exists "${container}" upstream
     assertTrue "Manifest file(s) do(es) not exist or is(are) empty in image" $?
 }
 

--- a/oci-unit-tests/grafana_test.sh
+++ b/oci-unit-tests/grafana_test.sh
@@ -108,7 +108,7 @@ test_manifest_exists() {
     debug "Testing that the manifest file is available in the image"
     container=$(docker_run_server)
 
-    check_manifest_exists "${container}"
+    check_manifest_exists "${container}" manifest.yaml snapcraft.yaml
     assertTrue "Manifest file(s) do(es) not exist or is(are) empty in image" $?
 }
 

--- a/oci-unit-tests/prometheus-alertmanager_test.sh
+++ b/oci-unit-tests/prometheus-alertmanager_test.sh
@@ -87,7 +87,7 @@ test_manifest_exists() {
     debug "Testing that the manifest file is available in the image"
     container=$(docker_run_alertmanager)
 
-    check_manifest_exists "${container}"
+    check_manifest_exists "${container}" manifest.yaml snapcraft.yaml
     assertTrue "Manifest file(s) do(es) not exist or is(are) empty in image" $?
 }
 

--- a/oci-unit-tests/prometheus_test.sh
+++ b/oci-unit-tests/prometheus_test.sh
@@ -289,7 +289,7 @@ test_manifest_exists() {
     debug "Testing that the manifest file is available in the image"
     container=$(docker_run_prom)
 
-    check_manifest_exists "${container}"
+    check_manifest_exists "${container}" manifest.yaml snapcraft.yaml
     assertTrue "Manifest file(s) do(es) not exist or is(are) empty in image" $?
 }
 

--- a/oci-unit-tests/telegraf_test.sh
+++ b/oci-unit-tests/telegraf_test.sh
@@ -103,7 +103,7 @@ test_manifest_exists() {
     debug "Testing that the manifest file is available in the image"
     container=$(docker_run_telegraf)
 
-    check_manifest_exists "${container}"
+    check_manifest_exists "${container}" upstream
     assertTrue "Manifest file(s) do(es) not exist or is(are) empty in image" $?
 }
 


### PR DESCRIPTION
This will break tests for the following images, which need fixing:

- cassandra
- cortex
- grafana
- prometheus
- prometheus-alertmanager