### PR TITLE
oci: build cqlsh image from a release tag

### DIFF
--- a/oci-unit-tests/cassandra_test.sh
+++ b/oci-unit-tests/cassandra_test.sh
@@ -14,6 +14,7 @@
 
 readonly UPSTREAM_CASSANDRA_IMAGE="docker.io/cassandra:latest"
 readonly CQLSH_DOCKER_IMAGE="cassandra-cqlsh:test"
+readonly CQLSH_VERSION="${CQLSH_VERSION:-4.0.1}"
 # We build the cqlsh image locally because upstream does not ship a s390x image
 # See https://github.com/canonical/server-test-scripts/pull/130
 readonly USE_UPSTREAM_CASSANDRA_IMAGE=false
@@ -36,7 +37,8 @@ oneTimeSetUp() {
         docker rmi "${UPSTREAM_CASSANDRA_IMAGE}" > /dev/null 2>&1
     else
         debug "Building cqlsh image locally. This may take a while"
-        docker build -t "${CQLSH_DOCKER_IMAGE}" ./cassandra_test_data
+        docker build --build-arg CQLSH_VERSION="${CQLSH_VERSION}" \
+         -t "${CQLSH_DOCKER_IMAGE}" ./cassandra_test_data
     fi
 }
 

--- a/oci-unit-tests/cassandra_test_data/Dockerfile
+++ b/oci-unit-tests/cassandra_test_data/Dockerfile
@@ -1,8 +1,9 @@
 FROM ubuntu:impish
+ARG CQLSH_VERSION=4.0.1
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get full-upgrade -y && \
 	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 		git python3-pip build-essential python3-dev && \
-	git clone https://github.com/apache/cassandra.git && \
+	git clone -b cassandra-${CQLSH_VERSION} --depth 1 https://github.com/apache/cassandra.git && \
 	cd cassandra/pylib && pip install Cython && pip install -r requirements.txt && pip install .
 ENV PATH="/cassandra/bin:${PATH}"
 WORKDIR /cassandra


### PR DESCRIPTION
cqlsh is used to test the published Cassandra images. We currently do so
with the development version of cqlsh. This patch changes this behavior
to use a release version of cqlsh to avoid development issues with the
project builds.

Signed-off-by: Athos Ribeiro <athos.ribeiro@canonical.com>