### PR TITLE
oci: describe assertion errors

### DIFF
--- a/oci-unit-tests/memcached_test.sh
+++ b/oci-unit-tests/memcached_test.sh
@@ -55,8 +55,8 @@ test_local_connection() {
     container=$(docker_run_server)
     assertNotNull "Failed to start the container" "${container}" || return 1
 
-    docker exec "$container" /usr/share/memcached/scripts/memcached-tool 127.0.0.1:11211 > /dev/null
-    assertTrue $?
+    mtool_output=$(docker exec "$container" /usr/share/memcached/scripts/memcached-tool 127.0.0.1:11211)
+    assertTrue "Unexpected memcached-tool response:\n${mtool_output}" $?
 }
 
 test_network_connection() {
@@ -68,8 +68,8 @@ test_network_connection() {
     container_client=$(suffix=client docker_run_server)
     assertNotNull "Failed to start the container" "${container_client}" || return 1
 
-    docker exec "$container_client" /usr/share/memcached/scripts/memcached-tool "${DOCKER_PREFIX}_server:11211" > /dev/null
-    assertTrue $?
+    mtool_output=$(docker exec "$container_client" /usr/share/memcached/scripts/memcached-tool "${DOCKER_PREFIX}_server:11211")
+    assertTrue "Unexpected memcached-tool response:\n${mtool_output}" $?
 }
 
 test_custom_flags() {
@@ -91,8 +91,8 @@ test_custom_flags() {
     )
     assertNotNull "Failed to start the container" "${container}" || return 1
 
-    docker exec "$container" /usr/share/memcached/scripts/memcached-tool 127.0.0.1:22122 > /dev/null
-    assertTrue $?
+    mtool_output=$(docker exec "$container" /usr/share/memcached/scripts/memcached-tool 127.0.0.1:22122)
+    assertTrue "Unexpected memcached-tool response:\n${mtool_output}" $?
 }
 
 test_libmemcached_compliance() {
@@ -105,14 +105,14 @@ test_libmemcached_compliance() {
     assertNotNull "Failed to start the container" "${container_client}" || return 1
     install_container_packages "${container_client}" "libmemcached-tools" || return 1
 
-    docker exec "$container_client" memcping --servers="${DOCKER_PREFIX}_server"
-    assertTrue $?
-    docker exec "$container_client" memccat --servers="${DOCKER_PREFIX}_server"
-    assertTrue $?
-    docker exec "$container_client" memcflush --servers="${DOCKER_PREFIX}_server"
-    assertTrue $?
-    docker exec "$container_client" memcslap --servers="${DOCKER_PREFIX}_server"
-    assertTrue $?
+    mping_output=$(docker exec "$container_client" memcping --servers="${DOCKER_PREFIX}_server")
+    assertTrue "Unexpected memcping response:\n${mping_output}" $?
+    mcat_output=$(docker exec "$container_client" memccat --servers="${DOCKER_PREFIX}_server")
+    assertTrue "Unexpected memccat response:\n${mcat_output}" $?
+    mflush_output=$(docker exec "$container_client" memcflush --servers="${DOCKER_PREFIX}_server")
+    assertTrue "Unexpected memcflush response:\n${mflush_output}" $?
+    mslap_output=$(docker exec "$container_client" memcslap --servers="${DOCKER_PREFIX}_server")
+    assertTrue "Unexpected memcslap response:\n${mslap_output}" $?
 }
 
 test_data_storage_and_retrieval() {

--- a/oci-unit-tests/prometheus-alertmanager_test.sh
+++ b/oci-unit-tests/prometheus-alertmanager_test.sh
@@ -80,7 +80,8 @@ EOF
 
     debug "Check if the alert was successfully fired"
     response=$(curl --silent --request POST "http://localhost:${ALERTMANAGER_PORT}/api/v1/alerts" --data "[$data]")
-    assertTrue echo "${response}" | grep success >/dev/null
+    echo "${response}" | grep -qF success
+    assertTrue "'success' not found in response:\n${response}" $?
 }
 
 test_manifest_exists() {

--- a/oci-unit-tests/prometheus_test.sh
+++ b/oci-unit-tests/prometheus_test.sh
@@ -116,7 +116,7 @@ test_cli() {
     if echo "${out}" | grep "The Prometheus monitoring server" >/dev/null; then
         ret=0
     fi
-    assertTrue $ret
+    assertTrue "Unexpected help output:\n${out}" $ret
     rm -rf "${temp_dir}"
 }
 
@@ -167,7 +167,8 @@ EOF
 
     debug "Check if the alertmanager is configured"
     out=$(curl --silent "http://localhost:${PROM_PORT}/classic/status")
-    assertTrue echo "${out}" | grep "${alertmanager_url}" >/dev/null
+    echo "${out}" | grep -qF "${alertmanager_url}"
+    assertTrue "'${alertmanager_url}' not found in status page:\n${out}" $?
 }
 
 test_alerts_config() {
@@ -198,7 +199,8 @@ EOF
 
     debug "Check if the alert is active"
     out=$(curl --silent "http://localhost:${PROM_PORT}/classic/alerts")
-    assertTrue echo "${out}" | grep "${alert_name}" | grep active >/dev/null
+    echo "${out}" | grep "${alert_name}" | grep -qF active
+    assertTrue "Could not infer 'active' status from:\n${out}" $?
 }
 
 push_dummy_metric_data() {


### PR DESCRIPTION
This set of patches completes the work on always returning helpful error messages when test failures occur.