### PR TITLE
Test fence_ipmilan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 results.xml
 ha/virsh/config/
 ha/virsh/images/
+ha/virsh/virtualbmc.venv/

--- a/ha/virsh/create-vm.sh
+++ b/ha/virsh/create-vm.sh
@@ -4,11 +4,11 @@ set -eux -o pipefail
 
 : "${UBUNTU_SERIES:=jammy}"
 
-VM_NAME="${1}"
-WORK_DIR="${2:-$(pwd)}"
-CONFIG_DIR="${3:-"${WORK_DIR}/config"}"
-IMAGES_DIR="${4:-"${WORK_DIR}/images"}"
-PUB_KEY_FILE="${5:-"/home/$(whoami)/.ssh/id_rsa.pub"}"
+VM_NAME="test"
+WORK_DIR=$(pwd)
+CONFIG_DIR="${WORK_DIR}/config"
+IMAGES_DIR="${WORK_DIR}/images"
+PUB_KEY_FILE="/home/$(whoami)/.ssh/id_rsa.pub"
 
 CLOUD_IMAGE_FILENAME="${UBUNTU_SERIES}-server-cloudimg-amd64.img"
 CLOUD_IMAGE_URL="https://cloud-images.ubuntu.com/${UBUNTU_SERIES}/current/${CLOUD_IMAGE_FILENAME}"
@@ -19,6 +19,40 @@ RAM=1024
 VCPU=1
 
 HA_NETWORK="ha"
+
+while [[ $# -gt 0 ]]; do
+  option="$1"
+  case $option in
+    --vm-name)
+      VM_NAME="$2"
+      shift
+      shift
+      ;;
+    --work-dir)
+      WORK_DIR="$2"
+      shift
+      shift
+      ;;
+    --config-dir)
+      CONFIG_DIR="$2"
+      shift
+      shift
+      ;;
+    --images-dir)
+      IMAGES_DIR="$2"
+      shift
+      shift
+      ;;
+    --pub-key)
+      PUB_KEY_FILE="$2"
+      shift
+      shift
+      ;;
+    *)
+      # Do nothing
+      ;;
+  esac
+done
 
 setup_workdir() {
   mkdir -p "${IMAGES_DIR}"/base \

--- a/ha/virsh/run_tests.sh
+++ b/ha/virsh/run_tests.sh
@@ -7,6 +7,10 @@ source /etc/profile.d/libvirt-uri.sh
 
 test_failed=0
 for file in $TESTS; do
+  if [[ "$file" == "fence_ipmilan_test.sh" ]]; then
+    continue
+  fi
+
   AGENT=$(echo "$file" | grep -oP '(?<=/).+(?=\_)' | tr _ -)
   export AGENT=$AGENT
 

--- a/ha/virsh/setup-cluster.sh
+++ b/ha/virsh/setup-cluster.sh
@@ -46,7 +46,7 @@ check_requirements() {
 }
 
 create_service_vm() {
-  ${CREATE_VM_SCRIPT} "${VM_SERVICES}" "$(pwd)"
+  ${CREATE_VM_SCRIPT} --vm-name "${VM_SERVICES}" --work-dir "$(pwd)"
   sleep 180
   virsh list
   get_vm_services_ip_addresses
@@ -72,7 +72,7 @@ setup_service_vm() {
 
 create_nodes() {
   for vm in "${VM01}" "${VM02}" "${VM03}"; do
-    ${CREATE_VM_SCRIPT} "${vm}" "$(pwd)"
+    ${CREATE_VM_SCRIPT} --vm-name "${vm}" --work-dir "$(pwd)"
   done
   sleep 180
   virsh list

--- a/ha/virsh/tests/fence_ipmilan_test.sh
+++ b/ha/virsh/tests/fence_ipmilan_test.sh
@@ -1,0 +1,118 @@
+# shellcheck shell=bash
+
+# shellcheck disable=SC1090
+. "$(dirname "$0")/helper/test_helper.sh"
+# shellcheck disable=SC1090
+. "$(dirname "$0")/../vm_utils.sh"
+
+CREATE_VM_SCRIPT="$(pwd)/create-vm.sh"
+
+setup_vbmc() {
+  if [ ! -d "$(pwd)/virtualbmc.venv" ]; then
+    NEEDED_PKGS="python3-venv python3-dev libvirt-dev gcc"
+    for pkg in ${NEEDED_PKGS}; do
+      if ! dpkg -l "${pkg}"; then
+        echo "[E] ${pkg} is not installed."
+	exit 5
+      fi
+    done
+    python3 -m venv virtualbmc.venv
+  fi
+  # shellcheck source=/dev/null
+  source virtualbmc.venv/bin/activate
+  pip install -U pip
+  pip install virtualbmc
+  vbmcd
+}
+
+create_vm() {
+  name="${1}"
+  "${CREATE_VM_SCRIPT}" --vm-name "${name}"
+}
+
+get_tester_ip() {
+  sleep 30
+  IP_TESTER=$(virsh domifaddr "${TESTER}" | grep ipv4 | xargs | cut -d ' ' -f4 | cut -d '/' -f1)
+}
+
+setup_tester() {
+  # TODO: remove fence-agents once the fence_ipmilan is added to the -base package
+  run_command_in_node "${IP_TESTER}" "sudo apt-get update && \
+	  sudo apt-get install -y ipmitool fence-agents"
+}
+
+oneTimeSetUp() {
+  readonly TESTER="ipmi-tester"
+  readonly SIMULATOR="ipmi-simulator"
+  readonly PORT=6230
+  readonly USER="admin"
+  readonly PASSWD="password"
+
+  setup_vbmc
+  create_vm "${SIMULATOR}"
+  vbmc add "${SIMULATOR}" --port "${PORT}"
+  vbmc start "${SIMULATOR}"
+
+  create_vm "${TESTER}"
+  get_tester_ip
+  setup_tester
+
+  # shellcheck disable=SC2086,SC2116
+  PREFIX=$(echo ${IP_TESTER%.*})
+  readonly IP_HOST="${PREFIX}.1"
+}
+
+oneTimeTearDown() {
+  vbmc stop "${SIMULATOR}"
+  vbmc delete "${SIMULATOR}"
+  pkill vbmcd
+  deactivate
+
+  for vm in "${SIMULATOR}" "${TESTER}"; do
+    virsh destroy "${vm}"
+    virsh undefine --remove-all-storage "${vm}"
+  done
+}
+
+run_fence_ipmi() {
+  action="${1}"
+  run_command_in_node "${IP_TESTER}" "fence_ipmilan --ip=${IP_HOST} --ipport=${PORT} \
+	  --username=${USER} --password=${PASSWD} --lanplus --verbose --action=${action}"
+}
+
+test_simulator_is_running() {
+  status=$(run_fence_ipmi status)
+  [[ "${status}" == *"ON"* ]]
+  assertTrue $?
+
+  running_vms=$(virsh list --state-running --name)
+  echo "${running_vms}" | grep "${SIMULATOR}"
+  assertTrue $?
+}
+
+test_simulator_is_rebooted() {
+  status=$(run_fence_ipmi reboot)
+  echo "${status}"
+  [[ "${status}" == *"Rebooted"* ]]
+  assertTrue $?
+  [[ "${status}" == *"Success"* ]]
+  assertTrue $?
+}
+
+test_turn_simulator_on_and_off() {
+  status=$(run_fence_ipmi off)
+  echo "${status}"
+  [[ "${status}" == *"OFF"* ]]
+  assertTrue $?
+  [[ "${status}" == *"Success"* ]]
+  assertTrue $?
+
+  status=$(run_fence_ipmi on)
+  echo "${status}"
+  [[ "${status}" == *"ON"* ]]
+  assertTrue $?
+  [[ "${status}" == *"Success"* ]]
+  assertTrue $?
+}
+
+load_shunit2


### PR DESCRIPTION
Add some basic tests for `fence_ipmilan`. To do that `ipmi_sim` (provided by `openipmi`) was used to simulate IPMI and do not need real hardware with that feature. In order to make it simple, its tests run in a single VM and not in a corosync/pacemaker cluster, calling `fence_ipmilan` directly.