### PR TITLE
HA: use fence_sbd instead of external/sbd in the test

### DIFF
--- a/ha/virsh/tests/fence_sbd_test.sh
+++ b/ha/virsh/tests/fence_sbd_test.sh
@@ -36,9 +36,8 @@ configure_sbd() {
 configure_fence_sbd() {
   configure_watchdog
   configure_sbd
-  # TODO: remove the installation of fence-agents-extra once fence_sbd is added to fence-agents-common
-  run_in_all_nodes "sudo apt-get install -y fence-agents-extra"
-  run_command_in_node "${IP_VM01}" "sudo crm configure primitive ${RESOURCE_NAME} stonith:external/sbd" 
+  run_command_in_node "${IP_VM01}" "sudo crm configure primitive ${RESOURCE_NAME} stonith:fence_sbd \
+	  params devices=${MPATH_DEVICE}"
 }
 
 test_fence_sbd_is_started() {


### PR DESCRIPTION
I was mistakenly using `external/sbd` but that is not the agent that was
promoted to main, the correct one is `fence_sbd`.