### PR TITLE
OCI: Adjust git clone URL for "utils" repository

### DIFF
--- a/oci-unit-tests/standalone-checks_test.sh
+++ b/oci-unit-tests/standalone-checks_test.sh
@@ -28,7 +28,7 @@ oneTimeSetUp()
 
     UTILSDIR="${UTILSDIR}/utils"
 
-    if ! git clone -q --depth 1 https://git.launchpad.net/~canonical-server/ubuntu-docker-images/+git/utils "${UTILSDIR}"; then
+    if ! git clone -q --depth 1 https://git.launchpad.net/~ubuntu-docker-images/ubuntu-docker-images/+git/utils "${UTILSDIR}"; then
         echo "E: Failed to clone 'utils' repository.  Aborting." > /dev/stderr
         exit 1
     fi


### PR DESCRIPTION
We've recently transferred the ownership of the ROCK-related git
repositories from `~canonical-server` to `~ubuntu-docker-images`.  This
commit adjusts the `git clone` command on
`oci-unit-tests/standalone-checks_test.sh` to reflect that.