### PR TITLE
Fix delete call for azure resource groups

### DIFF
--- a/ubuntu-advantage-client/azure_cleanup.py
+++ b/ubuntu-advantage-client/azure_cleanup.py
@@ -129,7 +129,7 @@ def clean_azure(
                     resource_group_name = resource_group.name
                     print('# deleted resource group: {} with tag {}'.format(
                         resource_group_name, tag_value))
-                    result = resource_client.resource_groups.delete(
+                    result = resource_client.resource_groups.begin_delete(
                         resource_group_name=resource_group_name
                     )
 


### PR DESCRIPTION
We have updated the version we use for the Azure API in pycloudlib. This new API has new method for deleting resource groups. We are fixing the script to call the right method.