### PR TITLE
cleanup: update lxd prefix for pro client behave

### DIFF
--- a/ubuntu-advantage-client/lxd_cleanup.py
+++ b/ubuntu-advantage-client/lxd_cleanup.py
@@ -7,7 +7,7 @@ import datetime
 import json
 from subprocess import run, PIPE
 
-DEFAULT_NAME_PREFIX = "ubuntu-behave-test"
+DEFAULT_NAME_PREFIX = "upro-behave"
 
 
 def get_parser():


### PR DESCRIPTION
As part of the rename of UA to pro, we're changing the prefix of behave lxd instances for the pro client integration tests.

This is happening here: https://github.com/canonical/ubuntu-advantage-client/pull/2303

I'm not sure where this script is called. Because the prefix can be overridden, we should make sure any place we call this script is calling it correctly as well.