### PR TITLE
metric: add more disk and package info

### DIFF
--- a/metric-server-simple/data2influx.py
+++ b/metric-server-simple/data2influx.py
@@ -148,6 +148,16 @@ def parse_ports_measurement(fname, point):
     point["fields"] = {"portcount": int(count)}
 
 
+def parse_packages_measurement(fname, point):
+    """Parse raw package data of dpkg -l and extract measurement."""
+
+    with open(fname, "r", encoding="utf-8") as pkglist:
+        # minus header
+        count = len(pkglist.readlines()) - 5
+
+    point["fields"] = {"pkgcount": int(count)}
+
+
 def parse_meminfo_measurement(fname, point):
     """Parse raw data of meminfo output and extract measurement."""
 
@@ -217,6 +227,8 @@ def main(fname, metrictype, dryrun):
         parse_ports_measurement(fname, point)
     elif metrictype == "metric_disk":
         parse_disk_measurement(fname, point)
+    elif metrictype == "metric_packages":
+        parse_packages_measurement(fname, point)
     else:
         data = None
         print(f"WARNING: unknown metric type {metrictype}!")

--- a/metric-server-simple/metric-server-simple.sh
+++ b/metric-server-simple/metric-server-simple.sh
@@ -139,6 +139,21 @@ do_measurement_ports() {
 do_measurement_disk() {
   resultfile=$(get_result_filename "disk" "txt")
   Cexec df / --block-size=1M > "${resultfile}"
+
+  # Not parsed (yet), but great for later debugging of differences
+  resultfile=$(get_result_filename "diskdetail" "txt")
+  Cexec du  / --max-depth=2 >> "${resultfile}"
+}
+
+do_measurement_package() {
+  resultfile=$(get_result_filename "packages" "txt")
+  Cexec dpkg -l > "${resultfile}"
+
+  # Not parsed (yet), but great for later debugging of differences
+  resultfile=$(get_result_filename "packagesizes" "txt")
+  # This is intentional expanded by dpkg-query
+  # shellcheck disable=SC2016
+  Cexec dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n > "${resultfile}"
 }
 
 do_install_services() {


### PR DESCRIPTION
This is needed as a lessons learned from checking the results.