### PR TITLE
oci: force volume removal for squid tests

### DIFF
--- a/oci-unit-tests/squid_test.sh
+++ b/oci-unit-tests/squid_test.sh
@@ -42,7 +42,7 @@ tearDown() {
         stop_container_sync "${webserver}"
     fi
     if [ -n "${volume}" ]; then
-        docker volume rm "${volume}" > /dev/null 2>&1
+        docker volume rm -f "${volume}" > /dev/null 2>&1
     fi
 }
 


### PR DESCRIPTION
This may cause a test failure in any situation where this volume cannot be removed. Since we are using the volume name, which aims this specific test, it should be safe to go for a forced removal.