### PR TITLE
metric-server-simple: use longer lxc delete retry backoff

### DIFF
--- a/metric-server-simple/metric-server-simple.sh
+++ b/metric-server-simple/metric-server-simple.sh
@@ -18,7 +18,7 @@ INSTNAME=${INSTNAME-metric-server-simple-$RELEASE-$WHAT-$INSTTYPE}
 cleanup() {
   if lxc info "$INSTNAME" >/dev/null 2>&1; then
     echo "Cleaning up: $INSTNAME"
-    retry -t 3 -- lxc delete "$INSTNAME" --force
+    retry -t 3 -d 20,60,120 -- lxc delete "$INSTNAME" --force
   fi
 }
 


### PR DESCRIPTION
Hopefully with help avoiding 'dataset is busy' errors, which sometimes
go away by waiting.
