### PR TITLE
metric-server-simple: deepen disk report

### DIFF
--- a/metric-server-simple/metric-server-simple.sh
+++ b/metric-server-simple/metric-server-simple.sh
@@ -147,7 +147,7 @@ do_measurement_disk() {
 
   # Not parsed (yet), but great for later debugging of differences
   resultfile=$(get_result_filename "diskdetail" "txt")
-  Cexec du  / --exclude /dev --exclude /proc --exclude /sys --max-depth=2 >> "${resultfile}"
+  Cexec du  / --exclude /dev --exclude /proc --exclude /sys --max-depth=3 >> "${resultfile}"
 }
 
 do_measurement_package() {


### PR DESCRIPTION
We quite often see fluctuations in /usr/lib or /var/cache and going one level deeper would help a lot to point to the issue more quickly e.g. /var/cache/snap.