### PR TITLE
metric-server-simple: fix service-security

### DIFF
--- a/metric-server-simple/metric-server-simple.sh
+++ b/metric-server-simple/metric-server-simple.sh
@@ -139,7 +139,8 @@ do_measurement_meminfo() {
 do_measurement_servicesecurity() {
   # Check systemd service isolation feature usage
   resultfile=$(get_result_filename "userservicesecurity" "txt")
-  Cexec systemd-analyze security --no-pager --user > "${resultfile}"
+  # this needs a login session to work
+  Cexec su ubuntu --login -c 'systemd-analyze security --no-pager --user' > "${resultfile}"
   resultfile=$(get_result_filename "systemservicesecurity" "txt")
   Cexec systemd-analyze security --no-pager --system > "${resultfile}"
 }


### PR DESCRIPTION
LXD by default does not spawn a login shell, but that is required to get a systemd user scope session.

Without a login shell the context is missing and this will fail with `Failed to connect to bus: No medium found`