### PR TITLE
metric-server-simple: gather service status

### DIFF
--- a/metric-server-simple/metric-server-simple.sh
+++ b/metric-server-simple/metric-server-simple.sh
@@ -187,6 +187,13 @@ do_install_services() {
       openvpn strongswan
 }
 
+do_log_service_status() {
+    # We sometimes had bad service startup, putting this info to the log
+    # helps to sourt out what might be wrong, especially when not easily
+    # reproducible.
+    systemctl status --all
+}
+
 cleanup
 setup_lxd_minimal_remote
 setup_container
@@ -223,5 +230,7 @@ do_measurement_processcount
 do_measurement_disk
 do_measurement_package
 do_measurement_servicesecurity
+
+do_log_service_status
 
 cleanup


### PR DESCRIPTION
Sometimes a rare event might happen that is hard to recerate and debug later. So far we have seen two times that service startup was bad.

Therefore it would be very helpful to have at least the general final status of all services in the log as it might indicate what was broken.