### PR TITLE
metric-server-simple: ignore RC of systemd-analyze calls

### DIFF
--- a/metric-server-simple/metric-server-simple.sh
+++ b/metric-server-simple/metric-server-simple.sh
@@ -140,9 +140,9 @@ do_measurement_servicesecurity() {
   # Check systemd service isolation feature usage
   resultfile=$(get_result_filename "userservicesecurity" "txt")
   # this needs a login session to work
-  Cexec su ubuntu --login -c 'systemd-analyze security --no-pager --user' > "${resultfile}"
+  Cexec su ubuntu --login -c 'systemd-analyze security --no-pager --user' || true > "${resultfile}"
   resultfile=$(get_result_filename "systemservicesecurity" "txt")
-  Cexec systemd-analyze security --no-pager --system > "${resultfile}"
+  Cexec systemd-analyze security --no-pager --system || true > "${resultfile}"
 }
 
 do_measurement_ports() {


### PR DESCRIPTION
If nonzero we want to continue gathering the rest of the data.
