### PR TITLE
metric-server-simple: ignore RC of combined service status

### DIFF
--- a/metric-server-simple/metric-server-simple.sh
+++ b/metric-server-simple/metric-server-simple.sh
@@ -193,7 +193,7 @@ do_log_service_status() {
     # reproducible.
     # Ignore the RC which often is 4 meaning that a unit was referenced
     # but not found e.g. boot.automount in containers
-    systemctl status --all --no-pager || true
+    Cexec systemctl status --all --no-pager || true
 }
 
 cleanup

--- a/metric-server-simple/metric-server-simple.sh
+++ b/metric-server-simple/metric-server-simple.sh
@@ -191,7 +191,9 @@ do_log_service_status() {
     # We sometimes had bad service startup, putting this info to the log
     # helps to sourt out what might be wrong, especially when not easily
     # reproducible.
-    systemctl status --all
+    # Ignore the RC which often is 4 meaning that a unit was referenced
+    # but not found e.g. boot.automount in containers
+    systemctl status --all --no-pager || true
 }
 
 cleanup


### PR DESCRIPTION
The RC of systemctl status --all can easily be non-zero while not being fatal for the system or the metric run. Ignore that to not run into retries (wasting time) and then giving up eventually.

Fixes: 7f331de8