### PR TITLE
metric-server-simple: fix status redirect

### DIFF
--- a/metric-server-simple/metric-server-simple.sh
+++ b/metric-server-simple/metric-server-simple.sh
@@ -140,9 +140,9 @@ do_measurement_servicesecurity() {
   # Check systemd service isolation feature usage
   resultfile=$(get_result_filename "userservicesecurity" "txt")
   # this needs a login session to work
-  Cexec su ubuntu --login -c 'systemd-analyze security --no-pager --user' || true > "${resultfile}"
+  Cexec su ubuntu --login -c 'systemd-analyze security --no-pager --user' > "${resultfile}" || true
   resultfile=$(get_result_filename "systemservicesecurity" "txt")
-  Cexec systemd-analyze security --no-pager --system || true > "${resultfile}"
+  Cexec systemd-analyze security --no-pager --system > "${resultfile}" || true
 }
 
 do_measurement_ports() {


### PR DESCRIPTION
The || true recently added did break the redirection which no more is capturing the output of systemd-analyze. Since `true` has no output the file isn't created at all and breaks the import.

Change the order so that the output of systemd-analyze is redirected.

Fixes: f444e6e9