### PR TITLE
metric-server-simple: do not trace flaky cache values

### DIFF
--- a/metric-server-simple/data2influx.py
+++ b/metric-server-simple/data2influx.py
@@ -125,7 +125,7 @@ def parse_cpustat_measurement(fname, point):
 
 
 def parse_disk_measurement(fname, point):
-    """Parse raw data of vmstat output and extract measurement."""
+    """Parse raw data of df output and extract measurement."""
 
     with open(fname, "r", encoding="utf-8") as rawdataf:
         disk_lines = rawdataf.readlines()
@@ -137,6 +137,24 @@ def parse_disk_measurement(fname, point):
 
     point["fields"] = {
             "usedmb": int(disk_entry[2]),
+    }
+
+
+def parse_apt_measurement(fname, point):
+    """Parse raw data of du on apt dirs and extract measurement."""
+
+    with open(fname, "r", encoding="utf-8") as rawdataf:
+        apt_lines = rawdataf.readlines()
+        for apt_line in apt_lines:
+            apt_entries = apt_line.split()
+            if apt_entries[1] == "/var/lib/apt/":
+                apt_list_size = int(apt_entries[0])
+            if apt_entries[1] == "/var/cache/apt/":
+                apt_cache_size = int(apt_entries[0])
+
+    point["fields"] = {
+            "cache": apt_cache_size,
+            "lists": apt_list_size,
     }
 
 
@@ -251,6 +269,8 @@ def main(fname, metrictype, dryrun):
         parse_ports_measurement(fname, point)
     elif metrictype == "metric_disk":
         parse_disk_measurement(fname, point)
+    elif metrictype == "metric_apt":
+        parse_apt_measurement(fname, point)
     elif metrictype == "metric_packages":
         parse_packages_measurement(fname, point)
     elif metrictype == "metric_userservicesecurity":

--- a/metric-server-simple/metric-server-simple.sh
+++ b/metric-server-simple/metric-server-simple.sh
@@ -185,6 +185,7 @@ do_install_services() {
       nginx apache2 squid python3-django \
       dovecot-imapd dovecot-pop3d postfix \
       openvpn strongswan
+  Cexec apt clean
 }
 
 do_log_service_status() {

--- a/metric-server-simple/metric-server-simple.sh
+++ b/metric-server-simple/metric-server-simple.sh
@@ -156,7 +156,7 @@ do_measurement_disk() {
 
   # Not parsed (yet), but great for later debugging of differences
   resultfile=$(get_result_filename "diskdetail" "txt")
-  Cexec du  / --exclude /dev --exclude /proc --exclude /sys --max-depth=3 >> "${resultfile}"
+  Cexec du  / --exclude /dev --exclude /proc --exclude /sys --max-depth=4 >> "${resultfile}"
 }
 
 do_measurement_package() {


### PR DESCRIPTION
/var/cache/apt can fluctuate a lot depending on how many packages might need to be updated as (relative to the daily image) to install packages of the workload. We are not interested in those fluctuations as they would auto-clean over time anyway.

Therefore run `apt clean` after installing packages for the loaded stage, but we want to know the initial image size if e.g. a clean was forgotten on build, so do not clean it there.