### PR TITLE
metric-server-simple: increase VM size

### DIFF
--- a/metric-server-simple/metric-server-simple.sh
+++ b/metric-server-simple/metric-server-simple.sh
@@ -44,7 +44,7 @@ Cexec() {
 setup_container() {
   [ "$WHAT" = vm ] && vmflag=--vm || vmflag=""
   # shellcheck disable=SC2086
-  lxc launch "ubuntu-minimal-daily:$RELEASE" "$INSTNAME" --ephemeral $vmflag
+  lxc launch "ubuntu-minimal-daily:$RELEASE" "$INSTNAME" --ephemeral $vmflag -c limits.cpu=4 -c limits.memory=4GiB
 
   # Wait for instance to be able to accept commands
   retry -d 2 -t 90 -- lxc exec "$INSTNAME" true


### PR DESCRIPTION
Since the changes to the mantic minimal image this OOM crashes. On one hand that increase was worth to know about, but on the other hand all the data we get since then is flaky at beast.

While this change itself might shift values a bit, they will at least be more reliable again. The intention is to consider reverting  this change once [1][2] are resolved.

[1]: https://warthogs.atlassian.net/browse/CPC-2985
[2]: https://bugs.launchpad.net/cloud-images/+bug/2032933