### PR TITLE
openssh-ccache-check: Update testing PPA path

### DIFF
--- a/openssh-ccache-check/README.txt
+++ b/openssh-ccache-check/README.txt
@@ -5,6 +5,6 @@ This work is described in the US066 OpenSSH ccache spec[4].
 
 1. https://launchpad.net/~canonical-server/+archive/ubuntu/openssh-server-default-ccache
 2. https://launchpad.net/~canonical-server/+archive/ubuntu/openssh-server-default-ccache-proposed
-3. https://launchpad.net/~ahasenack/+archive/ubuntu/openssh-ccache-testing
+3. https://code.launchpad.net/~canonical-server/+archive/ubuntu/openssh-server-default-ccache-testing
 4. https://docs.google.com/document/d/1UJDtDNCbDxfaq10inp5nVlisbMh-zwxzpPR0Hp_UrnI/edit
 

--- a/openssh-ccache-check/openssh-ccache-check.py
+++ b/openssh-ccache-check/openssh-ccache-check.py
@@ -92,7 +92,7 @@ def main():
     openssh_ppa_release = CcachePPA(
         lp, "canonical-server", "openssh-server-default-ccache"
     )
-    openssh_ppa_testing = CcachePPA(lp, "ahasenack", "openssh-ccache-testing")
+    openssh_ppa_testing = CcachePPA(lp, "canonical-server", "openssh-server-default-ccache-testing")
     ppa_version = {}
     ppa_version["testing"] = openssh_ppa_testing.get_latest_version()
     ppa_version["proposed"] = openssh_ppa_proposed.get_latest_version()


### PR DESCRIPTION
This move was happening in parallel with the previous PR, but was done just now. I tested the new testing PPA and recipe, and it's good to go.