### PR TITLE
ha: do not assume all homes are /home/$USER

### DIFF
--- a/ha/virsh/README.md
+++ b/ha/virsh/README.md
@@ -18,7 +18,7 @@ eveything for you! Make sure you have the following packages installed:
 
 Moreover, a SSH key is needed in your host to be added to the `authorized_keys`
 file of each node. By default, the script will try to use
-`/home/$(whoami)/.ssh/id_rsa.pub` as your public SSH key.
+`${HOME}/.ssh/id_rsa.pub` as your public SSH key.
 
 The setup takes some time but when it is done you will be ready to ssh into the
 nodes and the Corosync/Pacemaker cluster will be all set. You can check the

--- a/ha/virsh/create-vm.sh
+++ b/ha/virsh/create-vm.sh
@@ -8,7 +8,7 @@ VM_NAME="test"
 WORK_DIR=$(pwd)
 CONFIG_DIR="${WORK_DIR}/config"
 IMAGES_DIR="${WORK_DIR}/images"
-PUB_KEY_FILE="/home/$(whoami)/.ssh/id_rsa.pub"
+PUB_KEY_FILE="${HOME}/.ssh/id_rsa.pub"
 
 CLOUD_IMAGE_FILENAME="${UBUNTU_SERIES}-server-cloudimg-amd64.img"
 CLOUD_IMAGE_URL="https://cloud-images.ubuntu.com/${UBUNTU_SERIES}/current/${CLOUD_IMAGE_FILENAME}"


### PR DESCRIPTION
When setting up the cluster, we have been assuming that all user home directories are in /home/$USER. That is not necessarily true and it is not true for the default root user home which is in /root.