### PR TITLE
ha: add backoff function

### DIFF
--- a/ha/virsh/tests/fence_ipmilan_test.sh
+++ b/ha/virsh/tests/fence_ipmilan_test.sh
@@ -75,8 +75,6 @@ oneTimeSetUp() {
   # shellcheck disable=SC2086,SC2116
   PREFIX=$(echo ${IP_TESTER%.*})
   readonly IP_HOST="${PREFIX}.1"
-
-  sleep 10
 }
 
 oneTimeTearDown() {

--- a/ha/virsh/vm_utils.sh
+++ b/ha/virsh/vm_utils.sh
@@ -160,16 +160,19 @@ backoff() {
   # CONDITION_FUNCTION_NAME: Function to determine wheather to backoff. It must
   # return 0 when no waiting is needed or 1 when we want to wait.
   # BACKOFF_FACTOR: Factor for exponential backoff function. Default value: 2.
-  # MAX_ATTEMPTS: Maximum number of attempts. This defaults to 7 so we wait at
+  # MAX_RETRIES: Maximum number of retries. This defaults to 7 so we wait at
   # most 254 seconds with the last wait being of 128 seconds.
   CONDITION_FUNCTION_NAME="${1}"
   BACKOFF_FACTOR="${2:-2}"
-  MAX_ATTEMPTS="${3:-7}"
-  for i in $(seq 1 ${MAX_ATTEMPTS}); do
-    sleep $((BACKOFF_FACTOR ** i))
+  MAX_RETRIES="${3:-7}"
+  for i in $(seq 0 ${MAX_RETRIES}); do
+    if [ i -gt 0 ]; then
+      sleep $((BACKOFF_FACTOR ** i))
+    fi
     if $CONDITION_FUNCTION_NAME; then
       return 0
     fi
   done
   echo "WARNING: wait condition not matched for ${CONDITION_FUNCTION_NAME}"
+  return 1
 }


### PR DESCRIPTION
This is my idea to replace all the loose sleep calls within our tests.

We implementa an exponential backoff function which evaluates another function passed by the caller. This function result determines whether we want to sleep or not. Each time the function passed by the caller fails, we calculate the new backoff time and sleep again until a maximum number of attempts.

In this first PR, I am only introducing the new function and using the fence_ipmilan test as a case. When this is merged, I will proceed to remove the sleep calls from the other tests.