### PR TITLE
m/metric-server-simple.sh: Improve handling of "cloud-init status --wait"

### DIFF
--- a/metric-server-simple/metric-server-simple.sh
+++ b/metric-server-simple/metric-server-simple.sh
@@ -51,7 +51,15 @@ setup_container() {
 
   # Wait for cloud-init to finish
   # Run as root as the ubuntu (uid 1000) user may not be ready yet.
-  Cexec cloud-init status --wait >/dev/null
+  #
+  # From Noble onwards, "cloud-init status --wait" can return other
+  # than zero.  We should only error out if the return code is 1.
+  if ! Cexec cloud-init status --wait >/dev/null; then
+    if [ "$?" -eq 1 ]; then
+      echo "ERROR: cloud-init failed to initialize"
+      exit 1
+    fi
+  fi
 
   # Silence known spikes
   Cexec systemctl mask --now unattended-upgrades.service


### PR DESCRIPTION
From Noble onwards, "cloud-init status --wait" can return other than
zero.  The script should only error out if the return code is 1.

@paride, this fixes a problem which has been affecting the Noble
metrics VM for a several days now.  WDYT?

Thanks!